### PR TITLE
MYCE-15 feat: 회원가입 및 이메일 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// JWT 라이브러리 추가

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// JWT 라이브러리 추가
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -56,13 +58,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
-
-	testLogging {
-		events "passed", "skipped", "failed", "standardOut", "standardError"
-		showExceptions true
-		exceptionFormat "full" // 스택 트레이스를 전체 출력
-		showStandardStreams true // System.out, System.err로 출력되는 내용도 포함
-	}
 }
 
 jacoco {
@@ -82,12 +77,11 @@ jacocoTestReport {
 }
 
 // SonarCloud 설정 추가
-sonar {
+sonarqube {
 	properties {
 		property "sonar.projectKey", "ECommerceCommunity_FeedShop_Backend"
 		property "sonar.organization", "ecommercecommunity"
 		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.token", System.getenv("SONAR_TOKEN")
 
 		// 코드 커버리지를 Jacoco 리포트와 연동
 		property "sonar.java.coveragePlugin", "jacoco"

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:17-jdk-alpine
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatch.java
+++ b/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatch.java
@@ -1,0 +1,18 @@
+package com.cMall.feedShop.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE}) // 클래스, 인터페이스, Enum에 적용 가능
+@Retention(RetentionPolicy.RUNTIME) // 런타임 시까지 유지
+@Constraint(validatedBy = CustomPasswordMatchValidator.class)
+public @interface CustomPasswordMatch {
+    String message() default "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatchValidator.java
+++ b/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatchValidator.java
@@ -1,0 +1,34 @@
+package com.cMall.feedShop.annotation;
+
+
+import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CustomPasswordMatchValidator implements ConstraintValidator<CustomPasswordMatch, UserSignUpRequest> {
+
+    @Override
+    public boolean isValid(UserSignUpRequest request, ConstraintValidatorContext context) {
+        if (request == null) {
+            return true; // null 객체는 이 검증의 대상이 아니라고 판단할 수 있음
+        }
+
+        // 비밀번호 또는 비밀번호 확인 필드가 null인 경우 (NotBlank 등 다른 검증이 선행되어야 함)
+        if (request.getPassword() == null || request.getConfirmPassword() == null) {
+            return false; // 둘 중 하나라도 null이면 일치하지 않는 것으로 간주
+        }
+
+        // 실제 비밀번호 일치 여부 검사
+        boolean isValid = request.getPassword().equals(request.getConfirmPassword());
+
+        // 검증 실패 시 기본 메시지 대신 커스텀 메시지를 추가하고 싶다면
+        if (!isValid) {
+            context.disableDefaultConstraintViolation(); // 기본 메시지 비활성화
+            context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
+                    .addPropertyNode("confirmPassword") // 어떤 필드에 에러를 추가할지 지정
+                    .addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/BaseTimeEntity.java
+++ b/src/main/java/com/cMall/feedShop/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.cMall.feedShop.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter // Lombok: 모든 필드에 대한 getter 메서드를 자동으로 생성해줍니다.
+@MappedSuperclass // JPA: 이 클래스가 엔티티들의 상위 클래스임을 나타냅니다. 이 클래스의 필드들은 자식 엔티티의 테이블 컬럼으로 매핑됩니다. (테이블로 생성되지는 않음)
+@EntityListeners(AuditingEntityListener.class) // JPA: 엔티티의 영속성 이벤트(생성, 수정 등)를 감지하는 리스너를 지정합니다. 여기서는 Spring Data JPA의 Auditing 기능을 활성화합니다.
+public class BaseTimeEntity {
+    @CreatedDate // Spring Data JPA Auditing: 엔티티가 생성될 때 현재 시간을 자동으로 주입합니다.
+    @Column(name = "created_at", nullable = false, updatable = false) // JPA: 데이터베이스 컬럼명, null 허용 안 함, 업데이트 불가능
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // Spring Data JPA Auditing: 엔티티가 수정될 때마다 현재 시간을 자동으로 주입합니다.
+    @Column(name = "updated_at", nullable = false) // JPA: 데이터베이스 컬럼명, null 허용 안 함
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/cMall/feedShop/common/service/EmailService.java
+++ b/src/main/java/com/cMall/feedShop/common/service/EmailService.java
@@ -1,0 +1,55 @@
+package com.cMall.feedShop.common.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+    private final JavaMailSender emailSender;
+
+    // 간단한 텍스트 이메일 전송 메서드
+    public void sendSimpleEmail(String toEmail, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("jsm1592@gmail.com");
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(text);
+
+        try {
+            emailSender.send(message);
+            log.info("이메일 전송 성공: To={}, Subject={}", toEmail, subject);
+        } catch (MailException e) {
+            log.error("이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
+            throw new RuntimeException("이메일 전송에 실패했습니다.", e);
+        }
+    }
+
+    // HTML 형식의 이메일 전송 메서드 (필요하다면 사용)
+    public void sendHtmlEmail(String toEmail, String subject, String htmlContent) {
+        try {
+            MimeMessage message = emailSender.createMimeMessage();
+            // true는 멀티파트 메시지(파일 첨부 등)를 허용하고, "UTF-8"은 인코딩을 지정합니다.
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom("jsm1592@gmail.com"); // 발신자 이메일
+            helper.setTo(toEmail); // 수신자 이메일
+            helper.setSubject(subject); // 이메일 제목
+            helper.setText(htmlContent, true); // true를 넣어 HTML임을 명시
+
+            emailSender.send(message);
+            log.info("HTML 이메일 전송 성공: To={}, Subject={}", toEmail, subject);
+        } catch (MessagingException e) {
+            log.error("HTML 이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
+            throw new RuntimeException("HTML 이메일 전송에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/PasswordEncoderConfig.java
@@ -1,0 +1,33 @@
+package com.cMall.feedShop.config;
+
+import com.cMall.feedShop.user.infrastructure.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class PasswordEncoderConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(customUserDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder);
+        return new ProviderManager(authenticationProvider);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
@@ -24,26 +24,6 @@ import java.util.List;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final CustomUserDetailsService customUserDetailsService;
-
-    public SecurityConfig(CustomUserDetailsService customUserDetailsService) {
-        this.customUserDetailsService = customUserDetailsService;
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(
-            PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
-        authenticationProvider.setUserDetailsService(customUserDetailsService);
-        authenticationProvider.setPasswordEncoder(passwordEncoder);
-        return new ProviderManager(authenticationProvider);
-    }
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
@@ -60,8 +40,8 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/public/**",
-                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/verify-email",
+                                "/public/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 // 폼 로그인 및 HTTP Basic 인증은 사용하지 않음

--- a/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.cMall.feedShop.config;
 
-import com.cMall.feedShop.user.domain.service.CustomUserDetailsService;
+import com.cMall.feedShop.user.infrastructure.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
@@ -1,13 +1,43 @@
 package com.cMall.feedShop.user.application.dto.request;
 
 import com.cMall.feedShop.annotation.CustomEncryption;
+import com.cMall.feedShop.annotation.CustomPasswordMatch;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
+@CustomPasswordMatch
 public class UserSignUpRequest {
-    private String loginId;
-    @CustomEncryption
-    private String password;
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    @Size(max = 255, message = "이메일은 255자 이하로 입력해주세요.")
     private String email;
+
+    private String loginId;
+
+    @CustomEncryption
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 255, message = "비밀번호는 8자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?])(?=.*[0-9]).*$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
+    private String confirmPassword; // 비밀번호 확인 필드
+
+    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     private String phone;
+
+    private UserRole role = UserRole.USER;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
@@ -17,6 +17,7 @@ public class UserResponse {
     private UserRole role; 
     private String status; 
     private LocalDateTime createdAt;
+    private String message;
 
     // User 엔티티를 UserResponse DTO로 변환하는 정적 팩토리 메서드
     public static UserResponse from(User user) {
@@ -24,10 +25,21 @@ public class UserResponse {
                 .userId(user.getId())
                 .username(user.getUsername())
                 .email(user.getEmail())
-                .phone(user.getPhone())
                 .role(user.getRole())
                 .status(user.getStatus().name()) // Enum을 String으로 변환하여 반환
                 .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+    public static UserResponse from(User user, String message) {
+        return UserResponse.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .status(user.getStatus().name()) // Enum을 String으로 변환하여 반환
+                .createdAt(user.getCreatedAt())
+                .message(message)
                 .build();
     }
 }

--- a/src/main/java/com/cMall/feedShop/user/application/service/BadgeService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/BadgeService.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.application.service;
+
+public class BadgeService {
+}

--- a/src/main/java/com/cMall/feedShop/user/application/service/CouponService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/CouponService.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.application.service;
+
+public class CouponService {
+}

--- a/src/main/java/com/cMall/feedShop/user/application/service/PointService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/PointService.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.application.service;
+
+public class PointService {
+}

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserAuthService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserAuthService.java
@@ -14,9 +14,11 @@ import org.springframework.security.authentication.AuthenticationManager; // Aut
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken; // UsernamePasswordAuthenticationToken import 추가
 import org.springframework.security.core.Authentication; // Authentication import 추가
 import org.springframework.security.core.userdetails.UsernameNotFoundException; // UsernameNotFoundException import 추가
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserAuthService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
@@ -1,78 +1,208 @@
 package com.cMall.feedShop.user.application.service;
 
 //import com.cMall.feedShop.user.application.dto.request.UserLoginRequest;
+import com.cMall.feedShop.common.service.EmailService;
 import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
 //import com.cMall.feedShop.user.application.dto.response.AuthTokenResponse;
 import com.cMall.feedShop.user.application.dto.response.UserResponse;
 import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.enums.UserRole;
 import com.cMall.feedShop.user.domain.enums.UserStatus;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.repository.UserProfileRepository;
 import com.cMall.feedShop.user.domain.repository.UserRepository;
-import lombok.RequiredArgsConstructor; // Lombok 임포트
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 // JWT 토큰 발급/검증을 위한 JwtProvider는 일단 주석 처리 (JWT 도입 전까지)
 // import com.cMall.feedShop.user.application.jwt.JwtProvider; // 가상의 JwtProvider
 
 @Service
 @Transactional
-@RequiredArgsConstructor // final 필드를 인자로 받는 생성자를 자동 생성
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     // private final JwtProvider jwtProvider;
+    private final UserProfileRepository userProfileRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
     public UserResponse signUp(UserSignUpRequest request) {
-        // 1. 중복 체크
-        if (userRepository.existsByLoginId(request.getLoginId())) {
-            throw new RuntimeException("이미 존재하는 사용자입니다.");
+        // 1. DTO 레벨 비밀번호 일치 검증 (CustomPasswordMatch 어노테이션 사용 시 컨트롤러에서 이미 처리됨)
+
+        // 2. 이메일 중복 확인 및 상태에 따른 처리
+        Optional<User> existingUserOptional = userRepository.findByEmail(request.getEmail());
+
+        if (existingUserOptional.isPresent()) {
+            User existingUser = existingUserOptional.get();
+
+            if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                // 이미 활성(ACTIVE) 상태의 사용자가 해당 이메일로 가입되어 있다면
+                throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            } else if (existingUser.getStatus() == UserStatus.PENDING) {
+                // PENDING 상태의 사용자가 존재한다면 (이메일 인증 미완료)
+                // 1. 기존 PENDING 계정의 인증 토큰 및 만료 시간 업데이트
+                String newVerificationToken = UUID.randomUUID().toString();
+                LocalDateTime newExpiryTime = LocalDateTime.now().plusHours(1);
+
+                existingUser.setVerificationToken(newVerificationToken);
+                existingUser.setVerificationTokenExpiry(newExpiryTime);
+                userRepository.save(existingUser); // 업데이트된 사용자 정보 저장
+
+                // 2. 사용자에게 재인증 메일 전송
+                String verificationLink = "https://localhost:8443/api/auth/verify-email?token=" + newVerificationToken;
+                String emailSubject = "[cMall] 회원가입 재인증을 완료해주세요.";
+                String emailContent = "안녕하세요, " + existingUser.getUserProfile().getName() + "님!\n\n" +
+                        "회원가입 재인증을 요청하셨습니다. 아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n\n" +
+                        verificationLink + "\n\n" +
+                        "본 링크는 1시간 후 만료됩니다.\n" +
+                        "감사합니다.\ncMall 팀 드림";
+
+                emailService.sendSimpleEmail(existingUser.getEmail(), emailSubject, emailContent);
+
+                // 예외를 던지는 대신, 성공 응답 반환
+                return UserResponse.from(
+                        existingUser,
+                        "재인증 메일이 발송되었습니다. 메일을 확인하여 인증을 완료해주세요."
+                );
+            }
+            // 기타 다른 상태 (DELETED 등)에 대한 처리도 추가할 수 있습니다.
         }
 
-        String encodedPasswordFromRequest = request.getPassword();
+        // 3. loginId 자동 생성 및 중복 확인
+        // UI에서 loginId를 받지 않으므로 UUID로 자동 생성
+        String generatedLoginId = UUID.randomUUID().toString(); // 고유성 보장
 
-        // 3. 사용자 생성 및 저장
+        // 4. 비밀번호 암호화
+        String finalPasswordToSave;
+        if (request.getPassword().startsWith("$2a$") || request.getPassword().startsWith("$2b$") || request.getPassword().startsWith("$2y$")) {
+            // 이미 암호화된 비밀번호로 판단 (AOP 적용 시)
+            finalPasswordToSave = request.getPassword();
+        } else {
+            // AOP가 적용되지 않았거나 디버깅 상황 등 평문 비밀번호인 경우
+            finalPasswordToSave = passwordEncoder.encode(request.getPassword());
+        }
+
+        // 5. User 엔티티 생성 및 초기화
         User user = new User(
-                request.getLoginId(),
-                encodedPasswordFromRequest, // 이미 암호화된 비밀번호 사용
-                request.getEmail(),
-                request.getPhone(),
-                UserRole.ROLE_USER
+                generatedLoginId, // 자동 생성된 loginId 사용
+                finalPasswordToSave, // 암호화된 비밀번호
+                request.getEmail(), // User 엔티티에 email 필드가 있다고 가정
+                UserRole.USER // 기본 역할 설정
         );
-        userRepository.save(user);
+        user.setStatus(UserStatus.PENDING);
+        user.setPasswordChangedAt(LocalDateTime.now()); // 초기 비밀번호 변경 시간 설정
 
-        // 4. UserResponse로 변환해서 반환
+        String verificationToken = UUID.randomUUID().toString(); // 이 줄이 먼저 와야 합니다!
+
+        LocalDateTime tokenExpiryTime = LocalDateTime.now().plusHours(1); // 예: 1시간 후 만료
+
+        user.setVerificationToken(verificationToken);
+        user.setVerificationTokenExpiry(tokenExpiryTime);
+
+        // 6. UserProfile 엔티티 생성
+        UserProfile userProfile = new UserProfile(
+                user,
+                request.getName(),
+                request.getName(),
+                request.getPhone()
+        );
+
+        user.setUserProfile(userProfile);
+
+        userRepository.save(user); // User에 cascade = CascadeType.ALL 설정 시 UserProfile도 함께 저장됨
+
+
+        // 이메일 전송
+        String verificationLink = "https://localhost:8443/api/auth/verify-email?token=" + verificationToken;
+        String emailSubject = "[cMall] 회원가입을 완료해주세요.";
+        String emailContent = "안녕하세요, " + request.getName() + "님!\n\n" +
+                "cMall 회원가입을 환영합니다. 아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n\n" +
+                verificationLink + "\n\n" +
+                "본 링크는 1시간 후 만료됩니다.\n" +
+                "감사합니다.\ncMall 팀 드림";
+
+        emailService.sendSimpleEmail(request.getEmail(), emailSubject, emailContent);
+
+        // 9. 응답 DTO 반환
         return UserResponse.from(user);
     }
 
+    // 아이디 중복 확인 메서드 (API 제공 시 활용)
+    @Transactional(readOnly = true)
+    public boolean isLoginIdDuplicated(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
 
-//    public AuthTokenResponse login(UserLoginRequest request) {
-        // 1. 사용자 검증
-//        User user = userRepository.findByUsername(request.getUsername())
-//                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
+    // 이메일 중복 확인 메서드 (API 제공 시 활용)
+    @Transactional(readOnly = true)
+    public boolean isEmailDuplicated(String email) {
+        return userRepository.existsByEmail(email); // User Repository 사용
+    }
 
-        // 2. 비밀번호 확인
-        // Aspect에서 사용한 PasswordEncryptionService의 matches 메서드를 사용해야 함
-        // 이를 위해 PasswordEncryptionService를 이 UserService에도 주입받아야 합니다.
-        // private final PasswordEncryptionService passwordEncryptionService;
-        // if (!passwordEncryptionService.matches(request.getPassword(), user.getPassword())) {
-        //     throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+    /**
+     * 이메일 인증 토큰을 검증하고 사용자 계정을 활성화합니다.
+     * @param token 사용자가 이메일 링크를 통해 전달한 인증 토큰
+     * @throws RuntimeException 토큰이 유효하지 않거나 만료되었을 경우 등
+     */
+    @Transactional
+    public void verifyEmail(String token) {
+        // 1. DB에서 해당 토큰을 가진 사용자를 찾습니다.
+        // Optional<User> userOptional = userRepository.findByVerificationToken(token);
+        // if (userOptional.isEmpty()) {
+        //     throw new RuntimeException("유효하지 않거나 찾을 수 없는 인증 토큰입니다.");
         // }
-        // 혹은, 여기에서 Spring Security의 PasswordEncoder를 다시 주입받아 사용할 수도 있습니다.
-        // private final PasswordEncoder passwordEncoder;
-        // if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-        //     throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-        // }
+        // User user = userOptional.get();
+
+        // 람다식을 활용하여 간결하게 작성
+        User user = userRepository.findByVerificationToken(token)
+                .orElseThrow(() -> new RuntimeException("유효하지 않거나 찾을 수 없는 인증 토큰입니다."));
 
 
-        // 3. JWT 토큰 생성 (JWT 미도입 시 이 부분은 주석 처리 또는 제거)
-        // String accessToken = jwtProvider.createAccessToken(user.getUsername(), user.getRole().name());
-        // String refreshToken = jwtProvider.createRefreshToken(user.getUsername());
+        // 2. 토큰이 유효한지 (만료되지 않았는지, 이미 사용되었는지) 확인합니다.
 
-        // 4. 토큰 반환 (JWT 미도입 시 적절한 응답으로 변경)
-        // return new AuthTokenResponse(accessToken, refreshToken);
-//        throw new UnsupportedOperationException("JWT is not enabled yet for login."); // 임시
-//    }
+        // 이미 ACTIVE 상태라면 (즉, 토큰이 이미 사용되었거나 이미 활성화된 계정이라면)
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            // 이미 활성화된 계정인데 다시 인증 시도하는 경우
+            // 이메일 인증 토큰 필드를 정리해주는 것이 좋음 (다음에 또 이 토큰으로 시도 못하게)
+            user.setVerificationToken(null);
+            user.setVerificationTokenExpiry(null);
+            userRepository.save(user); // 변경사항 저장
+            throw new RuntimeException("이미 인증이 완료된 계정입니다.");
+        }
+
+        // 토큰 자체가 null이거나
+        if (user.getVerificationToken() == null || !user.getVerificationToken().equals(token)) {
+            // 이 경우는 findByVerificationToken에서 이미 걸러지지만, 방어 코드로서 있을 수 있음
+            throw new RuntimeException("인증 토큰이 유효하지 않습니다.");
+        }
+
+        // 토큰이 만료되었는지 확인
+        // verificationTokenExpiry가 null이거나 현재 시간보다 이전이면 만료된 것으로 간주
+        if (user.getVerificationTokenExpiry() == null || user.getVerificationTokenExpiry().isBefore(LocalDateTime.now())) {
+            // 만료된 토큰이므로, 관련 필드를 초기화하고 사용자에게 재인증을 유도해야 함
+            user.setVerificationToken(null);
+            user.setVerificationTokenExpiry(null);
+            userRepository.save(user); // 변경사항 저장
+            throw new RuntimeException("인증 토큰이 만료되었습니다. 다시 회원가입을 시도하거나 인증 메일을 재발송해주세요.");
+        }
+
+        // 3. 유효하다면, 사용자의 UserStatus를 PENDING -> ACTIVE로 변경합니다.
+        user.setStatus(UserStatus.ACTIVE);
+
+        // 4. 사용된 토큰은 무효화하거나 삭제합니다.
+        // 토큰 필드를 null로 설정하여 다시 사용될 수 없도록 합니다.
+        user.setVerificationToken(null);
+        user.setVerificationTokenExpiry(null);
+
+        // 5. 변경된 사용자 정보를 저장합니다. (Transactional 어노테이션 덕분에 자동으로 DB에 반영)
+        userRepository.save(user); // 이 save는 변경 감지 후 자동으로 동작할 수 있지만, 명시적으로 호출하는 것도 안전함
+    }
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/DiscountType.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/DiscountType.java
@@ -1,0 +1,6 @@
+package com.cMall.feedShop.user.domain.enums;
+
+public enum DiscountType {
+    FIXED_DISCOUNT,
+    RATE_DISCOUNT
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/UserCouponStatus.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/UserCouponStatus.java
@@ -1,0 +1,7 @@
+package com.cMall.feedShop.user.domain.enums;
+
+public enum UserCouponStatus {
+    ACTIVE,     // 활성 (사용 가능)
+    USED,       // 사용됨
+    EXPIRED     // 만료됨
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/UserRole.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/UserRole.java
@@ -1,7 +1,7 @@
 package com.cMall.feedShop.user.domain.enums;
 
 public enum UserRole {
-    ROLE_ADMIN,
-    ROLE_SELLER,
-    ROLE_USER
+    ADMIN,
+    SELLER,
+    USER
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/UserStatus.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/UserStatus.java
@@ -5,5 +5,6 @@ public enum UserStatus {
     ACTIVE,
     INACTIVE,
     BLOCKED,
+    PENDING,
     SUSPENDED
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/model/CouponDefinition.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/CouponDefinition.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.model;
+
+public class CouponDefinition {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/model/PointTransaction.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/PointTransaction.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.model;
+
+public class PointTransaction {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/model/UserBadge.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/UserBadge.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.model;
+
+public class UserBadge {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/model/UserCoupon.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/UserCoupon.java
@@ -1,0 +1,52 @@
+package com.cMall.feedShop.user.domain.model;
+
+import com.cMall.feedShop.user.domain.enums.DiscountType;
+import com.cMall.feedShop.user.domain.enums.UserCouponStatus;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+public class UserCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="coupon_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable=false)
+    private User user;
+
+    @Column(name="coupon_code", nullable=false,  unique=true)
+    private String couponCode;
+
+    @Column(name="coupon_name", nullable = false)
+    private String couponName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="discount_type", nullable = false)
+    private DiscountType discountType;
+
+    @Column(name="discount_value")
+    private Double discountValue;
+
+    @Column(name="is_free_shiping", nullable = false)
+    private boolean isFreeShipping = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="coupon_status", nullable = false)
+    private UserCouponStatus couponStatus = UserCouponStatus.ACTIVE;
+
+    @CreatedDate
+    @Column(name="issued_at", nullable = false, updatable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name="expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/model/UserPoint.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/UserPoint.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.model;
+
+public class UserPoint {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/model/UserProfile.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/UserProfile.java
@@ -2,10 +2,14 @@ package com.cMall.feedShop.user.domain.model;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users_profile")
 @Getter
+@Setter
+@NoArgsConstructor
 public class UserProfile {
 
     @Id
@@ -22,4 +26,14 @@ public class UserProfile {
 
     @Column(name="nickname")
     private String nickname;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
+
+    public UserProfile(User user, String name, String nickname, String phone) {
+        this.user = user;
+        this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+    }
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/CouponDefinitionRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/CouponDefinitionRepository.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.repository;
+
+public interface CouponDefinitionRepository {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/PointTransactionRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/PointTransactionRepository.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.repository;
+
+public interface PointTransactionRepository {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserBadgeRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserBadgeRepository.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.repository;
+
+public interface UserBadgeRepository {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserCouponRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserCouponRepository.java
@@ -1,0 +1,14 @@
+package com.cMall.feedShop.user.domain.repository;
+
+import com.cMall.feedShop.user.domain.enums.UserCouponStatus;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.model.UserCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon,Long> {
+    List<UserCoupon> findByUserAndCouponStatus(User user, UserCouponStatus couponStatus);
+    Optional<UserCoupon> findByCouponCode(String couponCode);
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserPointRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserPointRepository.java
@@ -1,0 +1,4 @@
+package com.cMall.feedShop.user.domain.repository;
+
+public interface UserPointRepository {
+}

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
@@ -7,9 +7,13 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByLoginId(String loginId);
-
     Optional<User> findByLoginId(String loginId);
 
+    boolean existsByLoginId(String loginId);
+
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email); // email 중복 여부 확인 (signUp 시 사용)
+
+    Optional<User> findByVerificationToken(String verificationToken);
+
 }

--- a/src/main/java/com/cMall/feedShop/user/infrastructure/service/BCryptPasswordEncryptionService.java
+++ b/src/main/java/com/cMall/feedShop/user/infrastructure/service/BCryptPasswordEncryptionService.java
@@ -1,5 +1,6 @@
-package com.cMall.feedShop.user.domain.service;
+package com.cMall.feedShop.user.infrastructure.service;
 
+import com.cMall.feedShop.user.domain.service.PasswordEncryptionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/cMall/feedShop/user/infrastructure/service/CustomUserDetailsService.java
+++ b/src/main/java/com/cMall/feedShop/user/infrastructure/service/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.cMall.feedShop.user.domain.service; // 또는 적절한 패키지 경로
+package com.cMall.feedShop.user.infrastructure.service; // 또는 적절한 패키지 경로
 
 import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.repository.UserRepository;

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
@@ -10,34 +10,31 @@ import com.cMall.feedShop.user.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor; // Lombok 임포트
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth") // 인증 관련 엔드포인트 기본 경로
-@RequiredArgsConstructor // final 필드를 인자로 받는 생성자를 자동 생성
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class UserAuthController {
 
-    private final UserService userService; // 회원가입 등 기본적인 사용자 CRUD를 담당하는 서비스
-    private final UserAuthService userAuthService; // 로그인 등 인증 관련 로직을 담당하는 서비스
+    private final UserService userService;
+    private final UserAuthService userAuthService;
 
-    // @RequiredArgsConstructor가 생성자를 자동으로 만들어주므로 수동 생성자 삭제
-    // public AuthController(UserService userService, UserAuthService userAuthService) {
-    //     this.userService = userService;
-    //     this.userAuthService = userAuthService;
-    // }
 
     @PostMapping("/signup") // POST /api/auth/signup 요청 처리
     public ResponseEntity<UserResponse> signUp(@Valid @RequestBody UserSignUpRequest request) {
-        // 회원가입은 UserService에 위임 (사용자 생성 로직)
         return ResponseEntity.ok(userService.signUp(request));
     }
 
     @PostMapping("/login") // POST /api/auth/login 요청 처리 (React 코드와 일치)
     public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody UserLoginRequest request) {
-        // 로그인 인증은 AuthService에 위임
         return ResponseEntity.ok(userAuthService.login(request));
+    }
+
+    @GetMapping("/verify-email") // <-- 이 부분이 URL의 /verify-email 경로와 GET 요청을 담당합니다.
+    public ResponseEntity<String> verifyEmail(@RequestParam("token") String token) {
+        // 실제 이메일 인증 로직은 UserService가 수행합니다.
+        userService.verifyEmail(token);
+        return ResponseEntity.ok("이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.");
     }
 }

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
@@ -19,10 +19,4 @@ public class UserController {
         UserProfileResponse response = userProfileService.getUserProfile(userId);
         return response;
     }
-
-    // JWT 로그인 메서드도 있다면 여기에 추가
-    // @PostMapping("/login")
-    // public AuthTokenResponse login(@RequestBody UserLoginRequest request) {
-    //     return userService.login(request);
-    // }
 }

--- a/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
+++ b/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
@@ -7,9 +7,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest
 class FeedShopApplicationTests {
-
     @Test
     void contextLoads() {
     }
-
 }

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder; // PasswordEncoder mock은 AuthenticationManager 내부에서 사용되므로 직접 필요없지만, 생성자에 있다면 Mock으로 주입
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -39,7 +40,7 @@ class UserAuthServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private PasswordEncoder passwordEncoder; // UserAuthService의 생성자에 있다면 Mock으로 필요
+    private PasswordEncoder passwordEncoder;
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
@@ -69,8 +70,8 @@ class UserAuthServiceTest {
         );
         // 테스트 객체 생성 시에는 생략하거나 mock 데이터를 직접 설정
         testUser.setId(1L);
-        testUser.setCreatedAt(LocalDateTime.now());
-        testUser.setUpdatedAt(LocalDateTime.now());
+        ReflectionTestUtils.setField(testUser, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(testUser, "updatedAt", LocalDateTime.now());
         testUser.setPasswordChangedAt(LocalDateTime.now());
 
         dummyToken = "dummy_jwt_token";

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
@@ -32,30 +32,29 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class) // JUnit 5에서 Mockito를 사용하기 위한 설정
+@ExtendWith(MockitoExtension.class)
 class UserAuthServiceTest {
 
-    @Mock // Mock 객체 생성
+    @Mock
     private UserRepository userRepository;
 
-    @Mock // Mock 객체 생성
+    @Mock
     private PasswordEncoder passwordEncoder; // UserAuthService의 생성자에 있다면 Mock으로 필요
 
-    @Mock // Mock 객체 생성
+    @Mock
     private JwtTokenProvider jwtTokenProvider;
 
-    @Mock // Mock 객체 생성
+    @Mock
     private AuthenticationManager authenticationManager;
 
     @InjectMocks // Mock 객체들을 주입받을 테스트 대상 서비스
     private UserAuthService userAuthService;
 
-    // 테스트에 사용될 공통 데이터
     private UserLoginRequest loginRequest;
     private User testUser;
     private String dummyToken;
 
-    @BeforeEach // 각 테스트 메서드 실행 전에 초기화
+    @BeforeEach
     void setUp() {
         loginRequest = new UserLoginRequest();
         loginRequest.setEmail("test@example.com");
@@ -65,8 +64,8 @@ class UserAuthServiceTest {
                 "testLoginId",
                 "encodedPassword123", // DB에 저장된 암호화된 비밀번호
                 "test@example.com",
-                "010-1234-5678",
-                UserRole.ROLE_USER
+//                "010-1234-5678",
+                UserRole.USER
         );
         // 테스트 객체 생성 시에는 생략하거나 mock 데이터를 직접 설정
         testUser.setId(1L);

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
@@ -1,0 +1,204 @@
+package com.cMall.feedShop.user.application.service;
+
+import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
+import com.cMall.feedShop.user.application.dto.response.UserResponse;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.enums.UserStatus;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.repository.UserProfileRepository;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock // 목(Mock) 객체로 만들 의존성들
+    private UserRepository userRepository;
+    @Mock
+    private UserProfileRepository userProfileRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks // 목 객체들을 주입할 대상 (테스트할 서비스)
+    private UserService userService;
+
+    private UserSignUpRequest signUpRequest; // 테스트용 회원가입 요청 DTO
+
+    @BeforeEach // 각 테스트 실행 전에 실행되는 초기화 메서드
+    void setUp() {
+        // Mock UserSignUpRequest 데이터 설정
+        signUpRequest = new UserSignUpRequest();
+        signUpRequest.setName("테스트유저");
+        signUpRequest.setEmail("test@example.com");
+        signUpRequest.setPassword("password123!");
+        signUpRequest.setConfirmPassword("password123!");
+        signUpRequest.setRole(UserRole.USER);
+        signUpRequest.setPhone("01012345678"); // UserProfile에 phone 필드가 있고 NOT NULL이므로 테스트 요청에도 추가
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 일반적인 경우")
+    void signUp_Success() {
+        // Given (테스트를 위한 사전 조건 설정)
+        // 1. 이메일이 존재하지 않음을 가정 (중복 아님)
+        given(userRepository.existsByEmail(anyString())).willReturn(false);
+
+        // 2. passwordEncoder.encode() 호출 시 "encoded_password" 반환하도록 Mock 설정
+        given(passwordEncoder.encode(anyString())).willReturn("encoded_password");
+
+        // 3. userRepository.save() 호출 시 실제 저장되는 것처럼 동작하도록 Mock 설정
+        // 저장될 User 객체를 받아서 ID를 설정하고, UserProfile도 연결하여 반환하도록 함
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0); // save 메서드에 전달된 User 객체를 가져옴
+            savedUser.setId(1L); // DB에서 ID가 할당되었다고 가정
+            savedUser.setStatus(UserStatus.ACTIVE); // 상태 설정
+            savedUser.setPasswordChangedAt(LocalDateTime.now()); // 비밀번호 변경 시간 설정
+
+            // UserProfile 객체 생성 및 User에 연결
+            UserProfile userProfile = new UserProfile(savedUser, signUpRequest.getName(), signUpRequest.getName(), signUpRequest.getPhone());
+            savedUser.setUserProfile(userProfile); // User 객체에 UserProfile 연결
+
+            return savedUser; // 저장된 User 객체 반환
+        });
+
+        // When (테스트 대상 메서드 실행)
+        UserResponse response = userService.signUp(signUpRequest);
+
+        // Then (예상 결과 검증)
+        assertThat(response).isNotNull();
+        assertThat(response.getEmail()).isEqualTo(signUpRequest.getEmail());
+        assertThat(response.getRole()).isEqualTo(UserRole.USER);
+        assertThat(response.getUserId()).isEqualTo(1L);
+
+
+        // verify (특정 메서드가 호출되었는지, 몇 번 호출되었는지 검증)
+        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail()); // 이메일 중복 체크 1번 호출
+        verify(passwordEncoder, times(1)).encode(signUpRequest.getPassword()); // 비밀번호 인코딩 1번 호출
+        verify(userRepository, times(1)).save(any(User.class)); // User 저장 1번 호출
+        // UserProfile은 User에 cascade 되어있다면 userProfileRepository.save()가 직접 호출되지 않을 수 있습니다.
+        // 그러므로 userProfileRepository에 대한 verify는 생략합니다.
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void signUp_Fail_EmailDuplication() {
+        // Given
+        given(userRepository.existsByEmail(anyString())).willReturn(true); // 이메일이 이미 존재함을 가정
+
+        // When & Then (예외 발생 여부 및 메시지 검증)
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
+                userService.signUp(signUpRequest)
+        );
+
+        assertThat(thrown.getMessage()).isEqualTo("이미 사용 중인 이메일입니다.");
+        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail()); // 이메일 중복 체크만 호출
+        verify(passwordEncoder, times(0)).encode(anyString()); // 이메일 중복 시 인코더 호출 안 됨
+        verify(userRepository, times(0)).save(any(User.class)); // 이메일 중복 시 저장 안 됨
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 비밀번호가 AOP에 의해 이미 암호화된 경우")
+    void signUp_Success_AOPEncryptedPassword() {
+        // Given
+        String preEncryptedPassword = "$2a$10$abcdefghijklmnopqrstuvwxyza.abcdefghijklmnopqrs."; // AOP가 이미 암호화한 비밀번호
+        signUpRequest.setPassword(preEncryptedPassword);
+        signUpRequest.setConfirmPassword(preEncryptedPassword); // Confirm password도 동일하게 설정
+
+        // 1. Email not exists
+        given(userRepository.existsByEmail(anyString())).willReturn(false);
+
+        // 2. Mock passwordEncoder.encode()
+        // AOP에 의해 이미 암호화된 경우 이 메서드는 호출되면 안 됩니다.
+        // 따라서 encode()가 호출될 경우 예외를 발생시키거나, 호출되지 않도록 설정합니다.
+        // 여기서는 호출되지 않을 것을 예상하므로, given 설정은 필요 없습니다.
+        // 만약 호출된다면 Mockito의 verify에서 times(0)으로 확인할 것입니다.
+
+        // 3. Mock userRepository.save
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            savedUser.setId(2L); // 다른 ID로 시뮬레이션
+            savedUser.setStatus(UserStatus.ACTIVE);
+            savedUser.setPasswordChangedAt(LocalDateTime.now());
+            savedUser.setCreatedAt(LocalDateTime.now());
+            savedUser.setUpdatedAt(LocalDateTime.now());
+
+            // UserProfile 객체 생성 및 User에 연결
+            UserProfile userProfile = new UserProfile(savedUser, signUpRequest.getName(), signUpRequest.getName(), signUpRequest.getPhone());
+            savedUser.setUserProfile(userProfile);
+            return savedUser;
+        });
+
+        // When
+        UserResponse response = userService.signUp(signUpRequest);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getEmail()).isEqualTo(signUpRequest.getEmail());
+        assertThat(response.getRole()).isEqualTo(UserRole.USER);
+        assertThat(response.getUserId()).isEqualTo(2L);
+
+        // Verify repository calls
+        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail());
+        // 가장 중요한 검증: passwordEncoder.encode()가 호출되지 않아야 합니다.
+        verify(passwordEncoder, times(0)).encode(anyString());
+        verify(userRepository, times(1)).save(any(User.class));
+
+        // User 엔티티에 저장된 비밀번호가 요청의 암호화된 비밀번호와 동일한지 확인
+        // (이 검증을 위해 save() 시 반환된 User 객체의 비밀번호를 확인할 방법이 필요)
+        // 위 given(userRepository.save())의 willAnswer 블록에서 savedUser.getPassword()를 확인하거나,
+        // 실제 User 객체의 save 상태를 더 정확히 모의해야 합니다.
+        // 여기서는 간략하게 save 호출 검증에 집중합니다.
+        // 더 정확한 테스트를 위해선 savedUser.getPassword()가 preEncryptedPassword와 같은지
+        // willAnswer 람다 내에서 assert를 추가할 수 있습니다.
+        // 예: assertThat(savedUser.getPassword()).isEqualTo(preEncryptedPassword);
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 이미 존재하는 경우")
+    void isEmailDuplicated_True() {
+        // Given
+        String existingEmail = "duplicate@example.com";
+        given(userRepository.existsByEmail(existingEmail)).willReturn(true);
+
+        // When
+        boolean isDuplicated = userService.isEmailDuplicated(existingEmail);
+
+        // Then
+        assertThat(isDuplicated).isTrue();
+        verify(userRepository, times(1)).existsByEmail(existingEmail); // existsByEmail 호출 확인
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 존재하지 않는 경우")
+    void isEmailDuplicated_False() {
+        // Given
+        String newEmail = "new@example.com";
+        given(userRepository.existsByEmail(newEmail)).willReturn(false);
+
+        // When
+        boolean isDuplicated = userService.isEmailDuplicated(newEmail);
+
+        // Then
+        assertThat(isDuplicated).isFalse();
+        verify(userRepository, times(1)).existsByEmail(newEmail); // existsByEmail 호출 확인
+    }
+}

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.cMall.feedShop.user.application.service;
 
+import com.cMall.feedShop.common.service.EmailService;
 import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
 import com.cMall.feedShop.user.application.dto.response.UserResponse;
 import com.cMall.feedShop.user.domain.enums.UserRole;
@@ -18,132 +19,110 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-    @Mock // 목(Mock) 객체로 만들 의존성들
+    @Mock
     private UserRepository userRepository;
     @Mock
     private UserProfileRepository userProfileRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @InjectMocks // 목 객체들을 주입할 대상 (테스트할 서비스)
+    @InjectMocks
     private UserService userService;
 
-    private UserSignUpRequest signUpRequest; // 테스트용 회원가입 요청 DTO
+    private UserSignUpRequest signUpRequest;
 
-    @BeforeEach // 각 테스트 실행 전에 실행되는 초기화 메서드
+    @Mock
+    private EmailService emailService;
+
+    @BeforeEach
     void setUp() {
-        // Mock UserSignUpRequest 데이터 설정
         signUpRequest = new UserSignUpRequest();
         signUpRequest.setName("테스트유저");
         signUpRequest.setEmail("test@example.com");
         signUpRequest.setPassword("password123!");
         signUpRequest.setConfirmPassword("password123!");
         signUpRequest.setRole(UserRole.USER);
-        signUpRequest.setPhone("01012345678"); // UserProfile에 phone 필드가 있고 NOT NULL이므로 테스트 요청에도 추가
+        signUpRequest.setPhone("01012345678");
     }
 
+    // 회원가입 성공 - 신규 가입 (PENDING 상태, 인증 메일 발송)
     @Test
-    @DisplayName("회원가입 성공 - 일반적인 경우")
-    void signUp_Success() {
-        // Given (테스트를 위한 사전 조건 설정)
-        // 1. 이메일이 존재하지 않음을 가정 (중복 아님)
-        given(userRepository.existsByEmail(anyString())).willReturn(false);
-
-        // 2. passwordEncoder.encode() 호출 시 "encoded_password" 반환하도록 Mock 설정
+    @DisplayName("회원가입 성공 - 신규 가입, 인증 메일 발송")
+    void signUp_Success_NewUser_Pending() {
+        // Given
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.empty());
         given(passwordEncoder.encode(anyString())).willReturn("encoded_password");
-
-        // 3. userRepository.save() 호출 시 실제 저장되는 것처럼 동작하도록 Mock 설정
-        // 저장될 User 객체를 받아서 ID를 설정하고, UserProfile도 연결하여 반환하도록 함
         given(userRepository.save(any(User.class))).willAnswer(invocation -> {
-            User savedUser = invocation.getArgument(0); // save 메서드에 전달된 User 객체를 가져옴
-            savedUser.setId(1L); // DB에서 ID가 할당되었다고 가정
-            savedUser.setStatus(UserStatus.ACTIVE); // 상태 설정
-            savedUser.setPasswordChangedAt(LocalDateTime.now()); // 비밀번호 변경 시간 설정
-
-            // UserProfile 객체 생성 및 User에 연결
-            UserProfile userProfile = new UserProfile(savedUser, signUpRequest.getName(), signUpRequest.getName(), signUpRequest.getPhone());
-            savedUser.setUserProfile(userProfile); // User 객체에 UserProfile 연결
-
-            return savedUser; // 저장된 User 객체 반환
+            User savedUser = invocation.getArgument(0);
+            savedUser.setId(1L);
+            return savedUser;
         });
 
-        // When (테스트 대상 메서드 실행)
+        // When
         UserResponse response = userService.signUp(signUpRequest);
 
-        // Then (예상 결과 검증)
+        // Then
         assertThat(response).isNotNull();
         assertThat(response.getEmail()).isEqualTo(signUpRequest.getEmail());
-        assertThat(response.getRole()).isEqualTo(UserRole.USER);
-        assertThat(response.getUserId()).isEqualTo(1L);
-
-
-        // verify (특정 메서드가 호출되었는지, 몇 번 호출되었는지 검증)
-        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail()); // 이메일 중복 체크 1번 호출
-        verify(passwordEncoder, times(1)).encode(signUpRequest.getPassword()); // 비밀번호 인코딩 1번 호출
-        verify(userRepository, times(1)).save(any(User.class)); // User 저장 1번 호출
-        // UserProfile은 User에 cascade 되어있다면 userProfileRepository.save()가 직접 호출되지 않을 수 있습니다.
-        // 그러므로 userProfileRepository에 대한 verify는 생략합니다.
+        verify(emailService, times(1)).sendSimpleEmail(
+                eq(signUpRequest.getEmail()),
+                contains("회원가입을 완료해주세요"),
+                contains("인증을 완료해주세요")
+        );
     }
 
+    // 회원가입 실패 - 이미 ACTIVE 상태
     @Test
-    @DisplayName("회원가입 실패 - 이메일 중복")
-    void signUp_Fail_EmailDuplication() {
+    @DisplayName("회원가입 실패 - 이미 ACTIVE 상태")
+    void signUp_Fail_ActiveUser() {
         // Given
-        given(userRepository.existsByEmail(anyString())).willReturn(true); // 이메일이 이미 존재함을 가정
+        User existingUser = new User();
+        existingUser.setStatus(UserStatus.ACTIVE);
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.of(existingUser));
 
-        // When & Then (예외 발생 여부 및 메시지 검증)
+        // When & Then
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
                 userService.signUp(signUpRequest)
         );
-
         assertThat(thrown.getMessage()).isEqualTo("이미 사용 중인 이메일입니다.");
-        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail()); // 이메일 중복 체크만 호출
-        verify(passwordEncoder, times(0)).encode(anyString()); // 이메일 중복 시 인코더 호출 안 됨
-        verify(userRepository, times(0)).save(any(User.class)); // 이메일 중복 시 저장 안 됨
+        verify(emailService, never()).sendSimpleEmail(anyString(), anyString(), anyString());
     }
 
     @Test
     @DisplayName("회원가입 성공 - 비밀번호가 AOP에 의해 이미 암호화된 경우")
     void signUp_Success_AOPEncryptedPassword() {
         // Given
-        String preEncryptedPassword = "$2a$10$abcdefghijklmnopqrstuvwxyza.abcdefghijklmnopqrs."; // AOP가 이미 암호화한 비밀번호
+        String preEncryptedPassword = "$2a$10$abcdefghijklmnopqrstuvwxyza.abcdefghijklmnopqrs.";
         signUpRequest.setPassword(preEncryptedPassword);
-        signUpRequest.setConfirmPassword(preEncryptedPassword); // Confirm password도 동일하게 설정
+        signUpRequest.setConfirmPassword(preEncryptedPassword);
 
-        // 1. Email not exists
-        given(userRepository.existsByEmail(anyString())).willReturn(false);
+        // findByEmail로 중복 체크 (이메일 없음)
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.empty());
 
-        // 2. Mock passwordEncoder.encode()
-        // AOP에 의해 이미 암호화된 경우 이 메서드는 호출되면 안 됩니다.
-        // 따라서 encode()가 호출될 경우 예외를 발생시키거나, 호출되지 않도록 설정합니다.
-        // 여기서는 호출되지 않을 것을 예상하므로, given 설정은 필요 없습니다.
-        // 만약 호출된다면 Mockito의 verify에서 times(0)으로 확인할 것입니다.
-
-        // 3. Mock userRepository.save
+        // passwordEncoder.encode()는 호출되지 않아야 함
+        // save 동작 mock
         given(userRepository.save(any(User.class))).willAnswer(invocation -> {
             User savedUser = invocation.getArgument(0);
-            savedUser.setId(2L); // 다른 ID로 시뮬레이션
+            savedUser.setId(2L);
             savedUser.setStatus(UserStatus.ACTIVE);
             savedUser.setPasswordChangedAt(LocalDateTime.now());
-            savedUser.setCreatedAt(LocalDateTime.now());
-            savedUser.setUpdatedAt(LocalDateTime.now());
-
-            // UserProfile 객체 생성 및 User에 연결
             UserProfile userProfile = new UserProfile(savedUser, signUpRequest.getName(), signUpRequest.getName(), signUpRequest.getPhone());
             savedUser.setUserProfile(userProfile);
+            // 비밀번호가 암호화된 값과 같은지 검증
+            assertThat(savedUser.getPassword()).isEqualTo(preEncryptedPassword);
             return savedUser;
         });
 
@@ -156,20 +135,67 @@ class UserServiceTest {
         assertThat(response.getRole()).isEqualTo(UserRole.USER);
         assertThat(response.getUserId()).isEqualTo(2L);
 
-        // Verify repository calls
-        verify(userRepository, times(1)).existsByEmail(signUpRequest.getEmail());
-        // 가장 중요한 검증: passwordEncoder.encode()가 호출되지 않아야 합니다.
+        // findByEmail만 호출됨
+        verify(userRepository, times(1)).findByEmail(signUpRequest.getEmail());
         verify(passwordEncoder, times(0)).encode(anyString());
         verify(userRepository, times(1)).save(any(User.class));
+    }
 
-        // User 엔티티에 저장된 비밀번호가 요청의 암호화된 비밀번호와 동일한지 확인
-        // (이 검증을 위해 save() 시 반환된 User 객체의 비밀번호를 확인할 방법이 필요)
-        // 위 given(userRepository.save())의 willAnswer 블록에서 savedUser.getPassword()를 확인하거나,
-        // 실제 User 객체의 save 상태를 더 정확히 모의해야 합니다.
-        // 여기서는 간략하게 save 호출 검증에 집중합니다.
-        // 더 정확한 테스트를 위해선 savedUser.getPassword()가 preEncryptedPassword와 같은지
-        // willAnswer 람다 내에서 assert를 추가할 수 있습니다.
-        // 예: assertThat(savedUser.getPassword()).isEqualTo(preEncryptedPassword);
+    // 이메일 인증 성공
+    @Test
+    @DisplayName("이메일 인증 성공")
+    void verifyEmail_Success() {
+        // Given
+        String token = "valid-token";
+        User user = new User();
+        user.setStatus(UserStatus.PENDING);
+        user.setVerificationToken(token);
+        user.setVerificationTokenExpiry(LocalDateTime.now().plusMinutes(30));
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.of(user));
+
+        // When
+        userService.verifyEmail(token);
+
+        // Then
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getVerificationToken()).isNull();
+        assertThat(user.getVerificationTokenExpiry()).isNull();
+        verify(userRepository, times(1)).save(user);
+    }
+
+    // 이메일 인증 실패 - 만료된 토큰
+    @Test
+    @DisplayName("이메일 인증 실패 - 만료된 토큰")
+    void verifyEmail_Fail_ExpiredToken() {
+        // Given
+        String token = "expired-token";
+        User user = new User();
+        user.setStatus(UserStatus.PENDING);
+        user.setVerificationToken(token);
+        user.setVerificationTokenExpiry(LocalDateTime.now().minusMinutes(1));
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.of(user));
+
+        // When & Then
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                userService.verifyEmail(token)
+        );
+        assertThat(thrown.getMessage()).contains("인증 토큰이 만료되었습니다");
+        verify(userRepository, times(1)).save(user);
+    }
+
+    // 이메일 인증 실패 - 잘못된 토큰
+    @Test
+    @DisplayName("이메일 인증 실패 - 잘못된 토큰")
+    void verifyEmail_Fail_InvalidToken() {
+        // Given
+        String token = "invalid-token";
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.empty());
+
+        // When & Then
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                userService.verifyEmail(token)
+        );
+        assertThat(thrown.getMessage()).contains("유효하지 않거나 찾을 수 없는 인증 토큰");
     }
 
     @Test


### PR DESCRIPTION
주요 변경 사항

회원가입 시 이메일 중복 및 상태(PENDING, ACTIVE)별 처리 로직 추가
이미 ACTIVE 상태면 예외 발생
PENDING 상태면 인증 토큰 갱신 및 재인증 메일 발송
회원가입 시 loginId를 UUID로 자동 생성
비밀번호 암호화 처리
회원가입 시 User, UserProfile 엔티티 생성 및 저장
회원가입 완료 후 이메일 인증 링크 발송
이메일 인증 토큰 검증 및 계정 활성화 로직 추가
토큰 만료, 중복 인증 등 예외 처리
이메일/아이디 중복 확인 메서드 추가
이메일 전송은 EmailService 사용
UserService의 회원가입/이메일 인증 로직 변경에 맞춰 테스트 전체 리팩토링 및 케이스 보강
비밀번호가 이미 암호화된 경우(AOP 등) 처리 테스트 추가
이메일 인증 성공/실패(만료, 잘못된 토큰) 케이스 명확화
이메일 중복 확인 API 테스트 보강
BaseTimeEntity 상속 구조에 맞는 테스트 코드 반영(ReflectionTestUtils 등)<hr></hr>
 이 PR은 회원가입 및 이메일 인증의 전체 플로우를 구현하며, 사용자 경험 및 보안성을 강화합니다.