### PR TITLE
회원 탈퇴 기능 추가 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY build/libs/feedShop-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.http.HttpStatus; // <-- 추가
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -51,6 +52,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/verify-email",
                                 "/public/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                        .requestMatchers("/api/users/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 // 폼 로그인 및 HTTP Basic 인증은 사용하지 않음
@@ -64,11 +66,13 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedOrigins(Arrays.asList(
+                "https://feedshop-frontend.vercel.app/", // 프론트엔드 실제 배포 주소
+                "http://localhost:3000"
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
-
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;

--- a/src/main/java/com/cMall/feedShop/user/domain/model/User.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/User.java
@@ -92,12 +92,11 @@ public class User extends BaseTimeEntity implements UserDetails {
         return loginId;
     }
 
-    // UserDetails 인터페이스의 다른 메서드 구현 (중요!)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // 사용자의 역할을 Spring Security의 권한(GrantedAuthority)으로 변환하여 반환합니다.
         // UserRole.USER -> new SimpleGrantedAuthority("USER")
-        return List.of(new SimpleGrantedAuthority(this.role.name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_"+this.role.name()));
     }
 
     @Override

--- a/src/main/java/com/cMall/feedShop/user/infrastructure/security/JwtTokenProvider.java
+++ b/src/main/java/com/cMall/feedShop/user/infrastructure/security/JwtTokenProvider.java
@@ -103,15 +103,9 @@ public class JwtTokenProvider {
                 .getBody();
 
         String email = claims.getSubject();
-        String role = claims.get("role", String.class);
-
         UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
 
-        Collection<? extends GrantedAuthority> authorities = Arrays.stream(role.split(","))
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-
-        return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }
 


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
Spring Security 권한 인식 문제 해결 및 JWT 토큰 검증 로직 개선


**Type**
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
Spring Security의 UserDetails 구현체(User.java)에서 getAuthorities() 메서드가 반환하는 권한 문자열에 "ROLE_" 접두사를 추가하도록 수정했습니다.

JWT 토큰 유효성 검증 로직을 간소화했습니다. 기존에는 토큰에서 role 정보를 직접 추출하여 GrantedAuthority 리스트를 만들었으나, 이제는 customUserDetailsService.loadUserByUsername(email)을 통해 로드된 UserDetails 객체의 권한을 직접 사용하도록 변경했습니다.

### 왜 필요했나요?
권한 인식 문제 해결: Spring Security의 hasRole() 표현식은 기본적으로 권한 문자열 앞에 "ROLE_" 접두사가 붙어있을 것을 기대합니다. 기존에는 this.role.name()만 반환하여 "USER", "ADMIN" 등의 문자열이 권한으로 부여되었고, 이로 인해 @PreAuthorize("hasRole('ADMIN')")와 같은 어노테이션이 제대로 동작하지 않았습니다. "ROLE_" 접두사를 추가하여 Spring Security의 기본 동작 방식과 일치하도록 수정했습니다.

JWT 토큰 검증 로직 간소화 및 일관성: JWT 토큰에 role 정보를 포함시켜 직접 파싱하는 것보다, 이미 사용자 정보를 로드하는 loadUserByUsername 메서드를 통해 UserDetails 객체를 가져오면 해당 객체에 정의된 권한을 사용하는 것이 더 일관성 있고 간결합니다. 이는 권한 관리 로직의 중복을 피하고 UserDetails의 단일 책임 원칙을 강화합니다.

---

## 🔧 How (구현 방법)
### 주요 변경사항
- src/main/java/com/cMall/feedShop/user/domain/model/User.java 파일의 getAuthorities() 메서드에서 반환 값에 "ROLE_" 접두사를 추가:
return List.of(new SimpleGrantedAuthority("ROLE_"+this.role.name()));

- src/main/java/com/cMall/feedShop/user/infrastructure/security/JwtTokenProvider.java 파일의 getAuthentication() 메서드에서 claims.get("role", String.class)로 역할을 추출하고 Arrays.stream으로 권한을 생성하는 부분을 제거하고, userDetails.getAuthorities()를 직접 사용하도록 변경:
return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());

### 기술적 접근
- Spring Security의 GrantedAuthority 인터페이스와 @PreAuthorize 어노테이션의 동작 방식을 이해하고, 권한 부여 시 "ROLE_" 접두사를 명시적으로 추가하여 프레임워크의 기본 인가(Authorization) 메커니즘과 호환되도록 했습니다.

- JWT 토큰에서 직접 역할을 추출하는 대신, UserDetailsService를 통해 로드된 UserDetails의 권한을 재사용하여 코드의 응집도를 높이고 불필요한 중복 로직을 제거했습니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
관리자 권한이 필요한 API 엔드포인트(@PreAuthorize("hasRole('ADMIN')")가 적용된 API)에 대해 관리자 계정으로 로그인 후 요청을 보내 정상적으로 접근 가능한지 확인했습니다.
관리자 권한 외에 다른 권한을 가진 사용자를 통해서 `adminWithdrawUserByEmail` api를 통해 delete 처리를 시도해보았습니다.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #69
- 지라 백로그: https://sesac-springboot.atlassian.net/browse/MYCE-47
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
 - User 도메인 모델의 role 필드(UserRole enum)의 이름을 그대로 사용하는 대신, Spring Security의 요구사항에 맞춰 "ROLE_" 접두사를 붙여주는 것이 중요합니다.

 - JWT 토큰에 role 클레임을 포함하는 것은 여전히 유효하지만, JwtTokenProvider 내부에서 해당 클레임을 직접 사용하여 권한을 생성하는 대신, UserDetailsService가 로드한 UserDetails의 권한을 사용하도록 변경함으로써 로직이 더 명확해졌습니다.
---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
