### PR TITLE
fix: Resolve SonarCloud PR analysis issue in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,19 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+# 워크플로우 레벨에서 권한 설정
+permissions:
+  contents: read # 코드 체크아웃을 위해 필요
+  pull-requests: write # SonarCloud PR Decoration (상태 업데이트, 댓글)을 위해 필요
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # SonarCloud PR 분석을 위해 전체 Git 히스토리 필요
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -32,6 +39,7 @@ jobs:
           SPRING_PROFILES_ACTIVE: test
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+
       - name: Generate Test Coverage Report
         run: ./gradlew jacocoTestReport
 
@@ -55,11 +63,10 @@ jobs:
           name: test-coverage
           path: build/reports/jacoco/test/jacocoTestReport.xml
 
-      - name: Analyze with SonarQube
-        run: |
-          ./gradlew sonar
+      - name: Analyze with SonarCloud # SonarCloud 공식 액션 사용
+        uses: SonarSource/sonarcloud-github-action@v2.2 # 최신 버전을 확인하고 사용하세요.
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub Actions에서 제공하는 기본 토큰
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}    # SonarCloud 인증 토큰
+        # build.gradle에 sonar.projectKey, sonar.organization, sonar.host.url 등이
+        # 이미 설정되어 있으므로 별도의 with: 파라미터는 필요 없음.

--- a/build.gradle
+++ b/build.gradle
@@ -93,11 +93,6 @@ sourceSets {
 	}
 }
 
-// Gradle 8.x 이상에서는 annotationProcessorGeneratedSourcesDirectory 옵션 제거
-// tasks.withType(JavaCompile).configureEach {
-// 	options.annotationProcessorGeneratedSourcesDirectory = querydslDir.get().asFile
-// }
-
 tasks.register('cleanQuerydsl', Delete) {
 	delete querydslDir
 }
@@ -109,9 +104,9 @@ clean {
 jacocoTestReport {
 	dependsOn test // jacocoTestReport 태스크가 test 태스크 실행 이후에 실행되도록 의존성 설정
 	reports {
-		xml.required = true // SonarCloud가 읽을 수 있도록 XML 리포트 필수
+		xml.required = true
 		csv.required = false
-		html.required = true // 사람이 읽기 쉬운 HTML 리포트도 생성 (선택 사항)
+		html.required = true
 	}
 	// 보고서가 생성될 경로 설정 (SonarCloud에서 이 경로를 참조하게 됨)
 	// destinationFile = file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml") // 기본 경로와 동일하면 명시하지 않아도 됨


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CI/CD 워크플로우(ci.yml)를 수정하여 SonarCloud Pull Request 분석 문제를 해결하고 코드 분석을 강화했습니다.

**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [x] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
actions/checkout 스텝에 fetch-depth: 0 옵션을 추가하여 Git 전체 히스토리를 가져오도록 변경했습니다.

워크플로우 레벨에 pull-requests: write 권한을 명시적으로 부여했습니다.

Analyze with SonarQube 스텝을 SonarSource/sonarcloud-github-action 공식 액션 사용으로 변경했습니다.

SonarCloud 분석 스텝에서 불필요한 환경 변수 (JWT_SECRET, APP_VERIFICATION_URL)를 제거했습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
Could not find the pullrequest with key '27' 오류 해결: 기존 워크플로우에서 Pull Request 시 SonarCloud 분석이 실패하는 문제를 해결하기 위함입니다. 이는 주로 SonarCloud가 PR 컨텍스트를 제대로 인식하지 못하거나, PR Decoration에 필요한 GitHub API 권한이 부족해서 발생했습니다.

코드 분석 정확도 향상: fetch-depth: 0 설정을 통해 SonarCloud가 PR의 변경 내용을 베이스 브랜치와 정확하게 비교하고 분석할 수 있게 합니다.

워크플로우 안정성 및 유지보수성 개선: 공식 SonarCloud GitHub Action을 사용하여 PR 관련 파라미터 자동 처리를 활용하고, 불필요한 환경 변수를 제거하여 CI/CD 파이프라인의 명확성을 높였습니다.
---

## 🔧 How (구현 방법)
### 주요 변경사항
- .github/workflows/ci.yml 파일 수정:

jobs.build.steps 내 actions/checkout@v4에 with: fetch-depth: 0 추가.

워크플로우 상단에 permissions: pull-requests: write 추가.

Analyze with SonarQube 스텝을 uses: SonarSource/sonarcloud-github-action@v2.2로 변경하고, env에 GITHUB_TOKEN과 SONAR_TOKEN만 남기도록 수정.

### 기술적 접근
- GitHub Actions의 보안 모델과 SonarCloud의 PR 분석 요구사항(전체 Git 히스토리, GitHub API 접근 권한)을 충족하도록 워크플로우를 구성했습니다.

SonarCloud GitHub Action은 PR 관련 환경 변수를 자동으로 처리해주므로, 수동으로 PR 파라미터를 설정할 필요 없이 안정적인 분석을 보장합니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

---

## ✅ Checklist
- [ ] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
