### PR TITLE
Develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,11 @@ jobs:
           path: build/reports/jacoco/test/jacocoTestReport.xml
 
       - name: Analyze with SonarQube
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         run: |
-          ./gradlew sonar \
-          -Dsonar.projectKey=ECommerceCommunity_FeedShop_Backend \
-          -Dsonar.projectName="FeedShop_Backend" \
-          -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
-          -Dsonar.organization=ecommercecommunity
+          ./gradlew sonar --debug
         env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Analyze with SonarQube
         run: |
-          ./gradlew sonar
+          ./gradlew sonar -Dsonar.branch.name=${{ github.ref_name }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           SPRING_PROFILES_ACTIVE: test
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
 
       - name: Generate Test Coverage Report
         run: ./gradlew jacocoTestReport

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ Thumbs.db             # Windows system files
 .env
 application.properties
 application-dev.properties
+src/main/resources/application-dev.properties
 application.yml
 logs/
-src/main/resources/keystore.p12
 
 # Gradle
 .gradle/
@@ -47,7 +47,9 @@ out/
 # VS Code
 .vscode/
 
-
 # Keystore files
+src/main/resources/keystore.p12
 keystore.p12
-src/main/resources/application-dev.properties
+
+# etc
+sonar_debug.log

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 
 	// devtools 배포 시에는 삭제
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
+++ b/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
@@ -13,8 +13,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @EnableAutoConfiguration(exclude = {MailSenderAutoConfiguration.class})
 @TestPropertySource(properties = {
-        "jwt.secret=your-test-jwt-secret-key-that-is-long-enough-for-testing-purposes-1234567890" // 32자 이상 권장
-})
+        "jwt.secret=${TEST_JWT_SECRET:default-test-secret-key-1234567890abcdef}"})
 class FeedShopApplicationTests {
 
     @MockBean


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
테스트 환경에서 JWT 비밀 키를 운영용 JWT_SECRET과 분리하기 위해 테스트 전용 TEST_JWT_SECRET 환경 변수를 도입했습니다.
.env 파일에 TEST_JWT_SECRET를 추가하고, CI 파이프라인(GitHub Actions) 및 테스트 코드에서 이를 사용하도록 수정했습니다.
### 왜 필요했나요?

<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
보안 강화: 테스트와 운영 환경의 JWT 비밀 키를 분리해 테스트용 토큰이 운영 환경에서 유효해질 위험을 방지.
환경 구분: 테스트와 운영 환경을 명확히 구분해 유지보수성과 안정성을 높임.
유연성: CI/CD 및 로컬 환경에서 테스트 전용 키를 독립적으로 관리 가능.
쇼핑몰 웹사이트는 사용자 인증(로그인, 결제 등)을 다루므로, 보안과 환경 분리가 중요.

---

## 🔧 How (구현 방법)
### 주요 변경사항
- .env 파일 업데이트:
TEST_JWT_SECRET=your-test-secret-key-1234567890abcdef를 추가해 테스트 전용 JWT 키 설정.
기존 jwt.secret은 운영 환경용으로 유지.
CI 파이프라인 수정:
GitHub Actions 워크플로우에서 Run Tests 단계의 환경 변수를 JWT_SECRET에서 TEST_JWT_SECRET로 변경:
```
- name: Run Tests
  run: ./gradlew test --continue
  env:
    SPRING_PROFILES_ACTIVE: test
    APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
    TEST_JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
```
GitHub Secrets에 TEST_JWT_SECRET 추가(32바이트 이상 테스트용 키).
Build Project와 Analyze with SonarQube 단계는 기존 JWT_SECRET 유지.
테스트 코드 수정:

@TestPropertySource를 수정해 jwt.secret이 TEST_JWT_SECRET에서 값을 가져오도록 설정:
```
@TestPropertySource(properties = {
        "jwt.secret=${TEST_JWT_SECRET:default-test-secret-key-1234567890abcdef}"
})
```

### 기술적 접근
- 환경 변수 분리: 테스트 환경에서 TEST_JWT_SECRET를 사용해 운영 환경(JWT_SECRET)과 독립적으로 관리.
기본값 제공: TEST_JWT_SECRET가 설정되지 않은 경우, HS256 기준 32바이트 이상의 기본값(default-test-secret-key-1234567890abcdef) 사용.
보안 고려: .env 파일이 .gitignore에 포함되어 외부 노출 방지.
최소 수정: 기존 CI 워크플로우와 테스트 코드에서 최소한의 변경으로 환경 분리 구현 Lill.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
로컬 환경에서 TEST_JWT_SECRET를 설정한 .env 파일로 테스트 실행.
JWT 생성/검증 테스트를 수행해 토큰 생성 및 검증이 정상 작동하는지 확인.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
TEST_JWT_SECRET의 키 길이는 HS256 요구사항(32바이트 이상)을 충족하도록 설정했습니다.
향후 BaseTest 클래스에 키 길이 검증 로직 추가를 고려 중입니다.
리뷰 시 CI 테스트 결과와 .env 설정 관련 피드백 부탁드립니다.
---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
