### PR TITLE
ciPRdevelop PR 시에는 Sonar 테스트 실행 안하게 ci 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Spring Boot CI Pipeline
 
+permissions:
+  contents: read
+  secrets: read
+
 on:
   push:
     branches: [ "main", "develop" ]
@@ -71,6 +75,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Analyze with SonarQube
+        # main 브랜치로의 'push' 이벤트이거나, main 브랜치로 향하는 'pull_request' 이벤트일 때만 실행
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')
         run: |
           ./gradlew sonar -Dsonar.branch.name=${{ github.ref_name }}
         env:


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CI/CD 파이프라인의 SonarQube 분석 트리거 조건을 개선했습니다.


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [x] 📝 Docs
- [x] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
기존: main 또는 develop 브랜치로 push 이벤트(병합 포함) 발생 시에만 SonarQube 분석 실행.

변경:

main 또는 develop 브랜치로 push 이벤트(병합 포함) 발생 시 SonarQube 분석 실행.

main 브랜치를 대상(base)으로 하는 pull_request 이벤트 발생 시 SonarQube 분석 실행.


### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
main 브랜치로의 PR 단계에서 코드 품질 사전 검증: 최종 배포 브랜치인 main으로 코드가 병합되기 전에 SonarQube 분석을 통해 잠재적인 코드 품질 문제나 보안 취약점을 미리 파악하고 수정할 수 있도록 하기 위함입니다.

develop 브랜치 PR 시 불필요한 분석 방지: develop 브랜치로의 PR에서는 SonarQube 분석을 건너뛰어 CI/CD 리소스를 효율적으로 사용하고, 개발 과정의 유연성을 유지합니다.

보안 유지: develop이나 main 브랜치에 대한 직접 푸시가 제한되어 있는 현재 워크플로우에 맞춰, push 이벤트는 주로 PR 병합 시에만 발생하므로 시크릿(SONAR_TOKEN) 보안은 여전히 유지됩니다.


---

## 🔧 How (구현 방법)
### 주요 변경사항
- ci.yml 파일 내 Analyze with SonarQube 스텝의 if 조건문을 아래와 같이 수정했습니다.

`if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')`

### 기술적 접근
- GitHub Actions의 이벤트 컨텍스트 변수인 github.event_name과 github.base_ref를 활용하여 SonarQube 분석을 트리거할 시점을 세분화했습니다.

github.event_name == 'push'는 모든 push 이벤트(직접 푸시 및 PR 병합)를 포괄합니다.

github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main'는 PR 이벤트 중에서도 대상 브랜치가 main인 경우만을 명확히 지정하여 SonarQube 분석을 실행하도록 했습니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
이 변경은 CI/CD 파이프라인의 Run Tests 스텝에는 영향을 주지 않으며, 모든 PR에서 테스트는 여전히 정상적으로 실행됩니다.
---

## ✅ Checklist
- [ ] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
