### PR TITLE
MYCE-199 refactor: MailGun 연동 방식을 SMTP에서 API로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'com.mailgun:mailgun-java:1.1.3'
 
 	// JWT 라이브러리 추가
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
+++ b/src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
@@ -1,59 +1,92 @@
+// src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
 package com.cMall.feedShop.common.service;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import com.mailgun.api.v3.MailgunMessagesApi;
+import com.mailgun.model.message.Message;
+import com.mailgun.model.message.MessageResponse;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
-@RequiredArgsConstructor
-@Slf4j
 public class EmailServiceImpl implements EmailService {
 
-    private final JavaMailSender emailSender;
+    private static final Logger logger = LoggerFactory.getLogger(EmailServiceImpl.class);
 
-    @Value("${spring.mail.username}")
-    private String fromEmailAddress;
+    private final String apiKey;
+    private final String domain;
+    private final String fromEmail;
+    private final MailgunMessagesApi mailgunMessagesApi;
+
+
+    public EmailServiceImpl(
+            @Value("${mailgun.api.key}") String apiKey,
+            @Value("${mailgun.domain}") String domain,
+            @Value("${mailgun.from.email}") String fromEmail,
+            // Spring은 이제 MailgunConfig에서 MailgunMessagesApi 빈을 찾을 것입니다.
+            MailgunMessagesApi mailgunMessagesApi) {
+        this.apiKey = apiKey;
+        this.domain = domain;
+        this.fromEmail = fromEmail;
+        this.mailgunMessagesApi = mailgunMessagesApi;
+        logger.info("EmailServiceImpl 초기화됨: apiKey: {}, domain: {}", apiKey, domain);
+    }
+
+    // 환경 변수 검증
+    @PostConstruct
+    public void validateConfig() {
+        Objects.requireNonNull(apiKey, "Mailgun API 키는 null이 아니어야 합니다");
+        Objects.requireNonNull(domain, "Mailgun 도메인은 null이 아니어야 합니다");
+        Objects.requireNonNull(fromEmail, "Mailgun 보내는 이메일은 null이 아니어야 합니다");
+        if (apiKey.isBlank() || domain.isBlank() || fromEmail.isBlank()) {
+            throw new IllegalStateException("Mailgun 설정 속성은 비어 있을 수 없습니다");
+        }
+        logger.info("Mailgun 설정이 EmailServiceImpl에서 성공적으로 검증되었습니다");
+    }
 
     @Override
     public void sendSimpleEmail(String toEmail, String subject, String text) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom(fromEmailAddress);
-        message.setTo(toEmail);
-        message.setSubject(subject);
-        message.setText(text);
+        Objects.requireNonNull(toEmail, "받는 이메일은 null이 아니어야 합니다");
+        Objects.requireNonNull(subject, "이메일 제목은 null이 아니어야 합니다");
+        Objects.requireNonNull(text, "이메일 본문은 null이 아니어야 합니다");
 
-        try {
-            emailSender.send(message);
-            log.info("이메일 전송 성공: To={}, Subject={}", toEmail, subject);
-        } catch (MailException e) {
-            log.error("이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
-            throw new RuntimeException("이메일 전송에 실패했습니다.", e);
-        }
+        Message message = Message.builder()
+                .from(fromEmail)
+                .to(toEmail)
+                .subject(subject)
+                .text(text)
+                .build();
+
+        sendMailgunMessage(message, toEmail);
     }
 
     @Override
     public void sendHtmlEmail(String toEmail, String subject, String htmlContent) {
+        Objects.requireNonNull(toEmail, "받는 이메일은 null이 아니어야 합니다");
+        Objects.requireNonNull(subject, "이메일 제목은 null이 아니어야 합니다");
+        Objects.requireNonNull(htmlContent, "이메일 HTML 내용은 null이 아니어야 합니다");
+
+        Message message = Message.builder()
+                .from(fromEmail)
+                .to(toEmail)
+                .subject(subject)
+                .html(htmlContent)
+                .build();
+
+        sendMailgunMessage(message, toEmail);
+    }
+
+    private void sendMailgunMessage(Message message, String toEmail) {
         try {
-            MimeMessage message = emailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-            helper.setFrom(fromEmailAddress);
-            helper.setTo(toEmail);
-            helper.setSubject(subject);
-            helper.setText(htmlContent, true);
-
-            emailSender.send(message);
-            log.info("HTML 이메일 전송 성공: To={}, Subject={}", toEmail, subject);
-        } catch (MessagingException e) {
-            log.error("HTML 이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
-            throw new RuntimeException("HTML 이메일 전송에 실패했습니다.", e);
+            MessageResponse response = mailgunMessagesApi.sendMessage(domain, message);
+            logger.info("Mailgun 이메일이 {}로 성공적으로 전송되었습니다: {}", toEmail, response.getMessage());
+        } catch (Exception e) {
+            logger.error("Mailgun 이메일 {} 전송 실패: {}", toEmail, e.getMessage(), e);
+            throw new RuntimeException("Mailgun 이메일 전송 실패: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/cMall/feedShop/config/MailGunConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/MailGunConfig.java
@@ -1,0 +1,29 @@
+package com.cMall.feedShop.config;
+
+import com.mailgun.api.v3.MailgunMessagesApi;
+import com.mailgun.client.MailgunClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+
+@Configuration
+public class MailGunConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(MailGunConfig.class);
+
+    @Value("${mailgun.api.key}") // application.properties 또는 application.yml에서 API 키를 주입합니다.
+    private String apiKey;
+
+    @Bean // 이 메서드가 Spring 빈을 생성하고 관리함을 나타냅니다.
+    public MailgunMessagesApi mailgunMessagesApi() {
+        logger.info("MailgunConfig에서 MailgunMessagesApi 빈을 API 키로 생성 중.");
+        return MailgunClient.config(apiKey) // 주입된 apiKey로 MailgunClient를 설정합니다.
+                .createApi(MailgunMessagesApi.class);
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -18,10 +18,13 @@ spring.h2.console.path=/h2-console
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE
 
-spring.mail.host=smtp.gmail.com
+spring.mail.host=smtp.mailgun.org
 spring.mail.port=587
-spring.mail.username=${MAIL_USERNAME:brad@sandbox5e63039302174a10a277a5c046516b36.mailgun.org}
 management.health.mail.enabled=false
+
+mailgun.api.key=${MAILGUN_API_KEY}
+mailgun.domain=${MAILGUN_DOMAIN}
+mailgun.from.email=${MAILGUN_EMAIL}
 
 app.verification-url=https://localhost:8443/api/auth/verify-email?token=
 app.password-reset-url=http://localhost:3000/reset-password

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,30 +1,29 @@
 spring.application.name=feedshop-test
 
+# H2 ?????? ?? (???? ??, ??? ?? ? DB ??)
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
+# JPA (Hibernate) ??
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# ?????? ?? ? ??? ?? ?? (??? ? ?? ???)
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+# ?? SSL ???? (??? ???? ???)
 server.ssl.enabled=false
 
+# H2 ?? ?? (??? ? DB ?? ???)
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
+# ?? ?? ?? (Hibernate SQL ?? ? ???? ?? ??)
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE
 
-spring.mail.host=smtp.mailgun.org
-spring.mail.port=587
-management.health.mail.enabled=false
-
-mailgun.api.key=${MAILGUN_API_KEY}
-mailgun.domain=${MAILGUN_DOMAIN}
-mailgun.from.email=${MAILGUN_EMAIL}
-
+# ?????? ?? URL
 app.verification-url=https://localhost:8443/api/auth/verify-email?token=
 app.password-reset-url=http://localhost:3000/reset-password


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
MailGun 이메일 전송 방식을 기존 SMTP에서 API 방식으로 변경하여 안정성 및 확장성을 개선합니다.


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->

 - MailGun 연동을 위한 JavaMailSender 기반의 SMTP 의존성을 제거하고, HTTP 통신 기반의 API
     클라이언트를 사용하도록 변경했습니다.
   - MailGunConfig를 수정하여 API 키와 도메인을 사용하도록 설정을 업데이트했습니다.
   - EmailServiceImpl의 메일 발송 로직을 MailGun API 호출 방식으로 재구현했습니다.


### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

- 안정성 향상: SMTP 방식은 연결 오류나 타임아웃 발생 시 원인 파악이 어렵지만, API 방식은
   명확한 HTTP 상태 코드와 응답 메시지를 통해 오류를 효과적으로 처리할 수 있습니다.
- 확장성 확보: API를 사용하면 이메일 발송뿐만 아니라 전송 성공/실패 추적, 오픈율, 클릭률 통계
   등 MailGun이 제공하는 다양한 부가 기능을 추후 쉽게 연동할 수 있습니다.
- 유지보수성 개선: 외부 라이브러리 의존성을 줄이고 표준 HTTP 클라이언트를 사용함으로써 코드
   구조를 단순화하고 유지보수를 용이하게 합니다.


---

## 🔧 How (구현 방법)
### 주요 변경사항

  - build.gradle: spring-boot-starter-mail 의존성을 제거했습니다. (또는 API 클라이언트
     라이브러리로 교체)
   - application.properties: 기존 SMTP 관련 설정을 제거하고 MailGun API 키, 도메인 설정을
     추가했습니다.
   - MailGunConfig.java: JavaMailSender Bean 설정을 제거하고, API 통신에 필요한 설정을
     추가했습니다.
   - EmailServiceImpl.java: JavaMailSender를 사용하던 로직을 MailGun API를 직접 호출하는
     로직으로 전면 수정했습니다.


### 기술적 접근

   - FeignClient (또는 RestTemplate, WebClient)을 사용하여 MailGun API와 통신하는 클라이언트
     인터페이스를 정의하고 구현했습니다.
   - MailGun API 인증을 위해 Authorization 헤더에 Base64로 인코딩된 API 키를 추가하는 로직을
     구현했습니다.
   - API 키와 같은 민감 정보는 @Value 어노테이션을 통해 application.properties에서 안전하게
     주입받도록 처리했습니다.


---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

   - 비밀번호 찾기, 회원가입 등 이메일 발송이 필요한 기능을 직접 실행하여 실제 메일이 정상적으로
     수신되는지 확인했습니다.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #384 
- 지라 백로그:  [https://sesac-springboot.atlassian.net/browse/MYCE-199](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

  - 리뷰어는 application-local.properties 또는 환경 변수에 mailgun.api-key, mailgun.domain 값을
     본인의 테스트용 값으로 설정해야 정상적으로 테스트할 수 있습니다.

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
