### PR TITLE
MYCE-154 feat: reCAPTCHA 테스트 코드 추가

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
@@ -16,6 +16,15 @@ public class BusinessException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
 
     // errorCode 문자열 반환 (리뷰 서비스 호환용)
     public String getErrorCodeString() {

--- a/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     INVALID_TOKEN(400, "U100", "유효하지 않거나 찾을 수 없는 토큰입니다."), // 일반적인 토큰 유효성 검사 실패 (찾을 수 없거나 잘못된 형식)
     TOKEN_EXPIRED(400, "U101", "토큰이 만료되었습니다. 비밀번호 재설정을 다시 시도해주세요."), // 토큰 만료
 
+    // 외부 API
+    MAILGUN_API_FAILED(502, "E001", "이메일 전송 중 외부 API 오류가 발생했습니다."),
+
     // reCAPTCHA
     RECAPTCHA_VERIFICATION_FAILED(400, "A003", "reCAPTCHA 인증에 실패했습니다."),
     RECAPTCHA_SCORE_TOO_LOW(400, "A004", "비정상적인 접근으로 의심되어 요청을 차단합니다."),

--- a/src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
+++ b/src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
@@ -1,18 +1,23 @@
 // src/main/java/com/cMall/feedShop/common/service/EmailServiceImpl.java
 package com.cMall.feedShop.common.service;
 
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
 import com.mailgun.api.v3.MailgunMessagesApi;
 import com.mailgun.model.message.Message;
 import com.mailgun.model.message.MessageResponse;
+import feign.FeignException;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
 @Service
+@Primary
 public class EmailServiceImpl implements EmailService {
 
     private static final Logger logger = LoggerFactory.getLogger(EmailServiceImpl.class);
@@ -85,9 +90,13 @@ public class EmailServiceImpl implements EmailService {
         try {
             MessageResponse response = mailgunMessagesApi.sendMessage(domain, message);
             logger.info("Mailgun 이메일이 {}로 성공적으로 전송되었습니다: {}", toEmail, response.getMessage());
-        } catch (Exception e) {
+        } catch (FeignException e) {
             logger.error("Mailgun 이메일 {} 전송 실패: {}", toEmail, e.getMessage(), e);
-            throw new RuntimeException("Mailgun 이메일 전송 실패: " + e.getMessage(), e);
+            throw new BusinessException(ErrorCode.MAILGUN_API_FAILED, "Mailgun 이메일 전송 실패: " + e.getMessage(), e);
+        } catch (Exception e) {
+            // 모든 예외를 포괄적으로 처리하고, 구체적인 에러 코드 사용
+            logger.error("Mailgun 이메일 {} 전송 실패: {}", toEmail, e.getMessage(), e);
+            throw new BusinessException(ErrorCode.MAILGUN_API_FAILED, "Mailgun 이메일 전송 실패: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/cMall/feedShop/config/RestTemplateConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.cMall.feedShop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/user/application/service/RecaptchaService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/RecaptchaService.java
@@ -10,6 +10,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Collections;
+
 @Slf4j
 @Service
 public class RecaptchaService {
@@ -22,12 +24,16 @@ public class RecaptchaService {
 
     private static final String GOOGLE_RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
 
+    private final RestTemplate restTemplate;
+
+    public RecaptchaService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
     public void verifyRecaptcha(String recaptchaToken, String expectedAction) {
         if (recaptchaToken == null || recaptchaToken.isEmpty()) {
             throw new BusinessException(ErrorCode.RECAPTCHA_VERIFICATION_FAILED, "reCAPTCHA 토큰이 없습니다.");
         }
-
-        RestTemplate restTemplate = new RestTemplate();
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("secret", secretKey);
@@ -36,7 +42,7 @@ public class RecaptchaService {
         RecaptchaResponse response = restTemplate.postForObject(GOOGLE_RECAPTCHA_VERIFY_URL, params, RecaptchaResponse.class);
 
         if (response == null || !response.isSuccess()) {
-            log.warn("reCAPTCHA API 검증 실패: {}", response != null ? response.getErrorCodes() : "응답 없음");
+            log.warn("reCAPTCHA API 검증 실패: {}", response != null ? (response.getErrorCodes() != null ? response.getErrorCodes() : Collections.emptyList()) : "응답 없음");
             throw new BusinessException(ErrorCode.RECAPTCHA_VERIFICATION_FAILED);
         }
 

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserAuthServiceImpl.java
@@ -13,6 +13,7 @@ import com.cMall.feedShop.user.domain.repository.PasswordResetTokenRepository;
 import com.cMall.feedShop.user.domain.repository.UserRepository;
 import com.cMall.feedShop.user.infrastructure.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class UserAuthServiceImpl implements UserAuthService {
 
@@ -39,6 +39,17 @@ public class UserAuthServiceImpl implements UserAuthService {
     @Value("${app.password-reset-url}")
     private String passwordResetBaseUrl;
 
+    public UserAuthServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder,
+                               PasswordResetTokenRepository passwordResetTokenRepository,
+                               @Qualifier("emailServiceImpl") EmailService emailService, // 빈 이름 확인 필요
+                               JwtTokenProvider jwtProvider, AuthenticationManager authenticationManager) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.passwordResetTokenRepository = passwordResetTokenRepository;
+        this.emailService = emailService;
+        this.jwtProvider = jwtProvider;
+        this.authenticationManager = authenticationManager;
+    }
     /**
      * 사용자 로그인 처리 메서드.
      * 로그인 ID와 비밀번호를 받아 사용자 인증을 수행하고, 성공 시 JWT 토큰을 발급합니다.

--- a/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
+++ b/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
@@ -11,15 +11,11 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
+import com.cMall.feedShop.common.service.EmailService;
 import com.cMall.feedShop.common.service.EmailServiceImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-
-interface MailgunService {
-    void sendEmail(String to, String subject, String text);
-}
-
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -28,7 +24,8 @@ interface MailgunService {
         "jwt.secret=${TEST_JWT_SECRET:default-test-secret-key-1234567890abcdef}",
         "mailgun.api.key=dummy-test-api-key",
         "mailgun.domain=dummy.test.domain",
-        "mailgun.from.email=dummy@test.com"
+        "mailgun.from.email=dummy@test.com",
+        "app.password-reset-url=http://localhost:3000/reset-password"
 })
 class FeedShopApplicationTests {
 
@@ -36,7 +33,7 @@ class FeedShopApplicationTests {
     private ApplicationContext applicationContext;
 
     @MockBean
-    private MailgunService mailgunService;
+    private EmailService emailService;
 
     @MockBean
     private EmailServiceImpl emailServiceImpl;
@@ -50,14 +47,66 @@ class FeedShopApplicationTests {
     }
 
     @Test
-    void testEmailSendingLogic() {
+    void testEmailServiceMocking() {
         String recipient = "user@example.com";
         String subject = "Welcome!";
         String body = "Thank you for registering.";
 
-        // mailgunService (Mock)가 호출되는지 검증
-        mailgunService.sendEmail(recipient, subject, body);
-        verify(mailgunService, times(1)).sendEmail(recipient, subject, body);
+        // EmailService Mock 동작 정의
+        doNothing().when(emailService).sendHtmlEmail(recipient, subject, body);
 
+        // Mock 호출
+        emailService.sendHtmlEmail(recipient, subject, body);
+
+        // 호출되었는지 검증
+        verify(emailService, times(1)).sendHtmlEmail(recipient, subject, body);
+    }
+
+    @Test
+    void testEmailServiceImplMocking() {
+        String recipient = "test@example.com";
+        String subject = "Test Subject";
+        String body = "Test Body";
+
+        // EmailServiceImpl Mock 동작 정의 (sendEmail 메서드 사용)
+        doNothing().when(emailServiceImpl).sendHtmlEmail(recipient, subject, body);
+
+        // Mock 호출
+        emailServiceImpl.sendHtmlEmail(recipient, subject, body);
+
+        // 검증
+        verify(emailServiceImpl, times(1)).sendHtmlEmail(recipient, subject, body);
+    }
+
+    @Test
+    void testRecaptchaServiceMocking() {
+        String token = "test-token";
+        String action = "test-action";
+
+        // RecaptchaService Mock 동작 정의
+        doNothing().when(recaptchaService).verifyRecaptcha(token, action);
+
+        // Mock 호출
+        recaptchaService.verifyRecaptcha(token, action);
+
+        // 검증
+        verify(recaptchaService, times(1)).verifyRecaptcha(token, action);
+    }
+
+    @Test
+    void testPasswordResetEmailFlow() {
+        // 비밀번호 재설정 이메일 발송 시나리오 테스트
+        String email = "user@example.com";
+        String subject = "[cMall] 비밀번호 재설정 안내";
+        String htmlContent = "비밀번호 재설정 링크가 포함된 HTML 내용";
+
+        // sendHtmlEmail 메서드 Mock 설정
+        doNothing().when(emailService).sendHtmlEmail(eq(email), eq(subject), anyString());
+
+        // 실제 서비스에서 호출되는 것처럼 테스트
+        emailService.sendHtmlEmail(email, subject, htmlContent);
+
+        // 검증
+        verify(emailService, times(1)).sendHtmlEmail(eq(email), eq(subject), anyString());
     }
 }

--- a/src/test/java/com/cMall/feedShop/user/application/service/RecaptchaServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/RecaptchaServiceTest.java
@@ -1,0 +1,125 @@
+package com.cMall.feedShop.user.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.user.application.dto.response.RecaptchaResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecaptchaServiceTest {
+
+    private RecaptchaService recaptchaService;
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    private final String testToken = "test-recaptcha-token";
+    private final String testAction = "login_submit";
+    private final String testSecretKey = "test-secret-key";
+    private final double testScoreThreshold = 0.5;
+
+    @BeforeEach
+    void setUp() {
+        recaptchaService = new RecaptchaService(mockRestTemplate);
+
+        // @Value로 주입되는 필드들을 직접 설정
+        ReflectionTestUtils.setField(recaptchaService, "secretKey", testSecretKey);
+        ReflectionTestUtils.setField(recaptchaService, "scoreThreshold", testScoreThreshold);
+    }
+
+    private RecaptchaResponse createMockResponse(boolean success, double score, String action) {
+        RecaptchaResponse response = new RecaptchaResponse();
+        response.setSuccess(success);
+        response.setScore(score);
+        response.setAction(action);
+        response.setErrorCodes(Collections.emptyList()); // errorCodes 초기화
+        return response;
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 성공")
+    void verifyRecaptcha_success() {
+        // given
+        RecaptchaResponse mockResponse = createMockResponse(true, 0.9, testAction);
+
+        when(mockRestTemplate.postForObject(any(String.class), any(MultiValueMap.class), eq(RecaptchaResponse.class)))
+                .thenReturn(mockResponse);
+
+        // when & then
+        assertDoesNotThrow(() -> recaptchaService.verifyRecaptcha(testToken, testAction));
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 토큰 없음")
+    void verifyRecaptcha_fail_noToken() {
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            recaptchaService.verifyRecaptcha(null, testAction);
+        });
+        assertEquals(ErrorCode.RECAPTCHA_VERIFICATION_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - API 응답 실패")
+    void verifyRecaptcha_fail_apiError() {
+        // given
+        RecaptchaResponse mockResponse = createMockResponse(false, 0.0, null);
+
+        when(mockRestTemplate.postForObject(any(String.class), any(MultiValueMap.class), eq(RecaptchaResponse.class)))
+                .thenReturn(mockResponse);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            recaptchaService.verifyRecaptcha(testToken, testAction);
+        });
+        assertEquals(ErrorCode.RECAPTCHA_VERIFICATION_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - Action 불일치")
+    void verifyRecaptcha_fail_actionMismatch() {
+        // given
+        RecaptchaResponse mockResponse = createMockResponse(true, 0.9, "different_action");
+
+        when(mockRestTemplate.postForObject(any(String.class), any(MultiValueMap.class), eq(RecaptchaResponse.class)))
+                .thenReturn(mockResponse);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            recaptchaService.verifyRecaptcha(testToken, testAction);
+        });
+        assertEquals(ErrorCode.RECAPTCHA_VERIFICATION_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 점수 미달")
+    void verifyRecaptcha_fail_scoreTooLow() {
+        // given
+        RecaptchaResponse mockResponse = createMockResponse(true, 0.4, testAction);
+
+        when(mockRestTemplate.postForObject(any(String.class), any(MultiValueMap.class), eq(RecaptchaResponse.class)))
+                .thenReturn(mockResponse);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            recaptchaService.verifyRecaptcha(testToken, testAction);
+        });
+        assertEquals(ErrorCode.RECAPTCHA_SCORE_TOO_LOW, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
Google reCAPTCHA 기능의 테스트 코드 작성 및 예외 처리 개선

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
무차별 대입  공격(봇 공격)을 막기 위한 captcha 기능의 테스트 코드를 작성하였습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

기능의 정상적인 동작을 확인 및 검증하여 코드의 안전성을 검증하고 혹시 모를 예외를 방지하고자 하였습니다.

---

## 🔧 How (구현 방법)
### 주요 변경사항
#### 1. 예외 처리 개선
- **BusinessException 클래스 확장**
  - `ErrorCode`와 `Throwable cause`를 받는 생성자 추가
  - `ErrorCode`, `String message`, `Throwable cause`를 받는 생성자 추가
  - 더 구체적인 예외 정보 전달 가능

#### 2. ErrorCode 추가
- **외부 API 관련 에러 코드 추가**
  - `MAILGUN_API_FAILED(502, "E001", "이메일 전송 중 외부 API 오류가 발생했습니다.")`

#### 3. EmailService 개선
- **예외 처리 강화**
  - `FeignException` 별도 처리 추가
  - 모든 예외를 `BusinessException`으로 래핑하여 일관된 에러 처리
  - `@Primary` 어노테이션 추가로 빈 우선순위 설정

#### 4. RestTemplate 설정 분리
- **RestTemplateConfig 클래스 신규 생성**
  - `RestTemplate` 빈 설정을 별도 클래스로 분리
  - 의존성 주입을 통한 테스트 용이성 향상

#### 5. RecaptchaService 개선
- **의존성 주입 방식 변경**
  - `RestTemplate`을 생성자 주입으로 변경
  - `NullPointerException` 방지를 위한 `Collections.emptyList()` 사용

#### 6. UserAuthServiceImpl 개선
- **생성자 주입 방식으로 변경**
  - `@RequiredArgsConstructor` 제거하고 명시적 생성자 구현
  - `@Qualifier`를 사용한 빈 이름 지정
  - 
### 🧪 테스트 코드 추가

#### 1. 통합 테스트 개선

- **EmailService Mock 테스트**
  - `testEmailServiceMocking()`: EmailService 인터페이스 Mock 테스트
  - `testEmailServiceImplMocking()`: EmailServiceImpl 구현체 Mock 테스트
  - `testRecaptchaServiceMocking()`: RecaptchaService Mock 테스트
  - `testPasswordResetEmailFlow()`: 비밀번호 재설정 이메일 플로우 테스트

#### 2. 테스트 환경 설정

- **테스트 프로퍼티 추가**
  - `app.password-reset-url=http://localhost:3000/reset-password` 추가
  - 테스트 환경에서 필요한 설정값 제공

## 🎯 개선 효과

### 1. 안정성 향상

- 외부 API 호출 시 발생할 수 있는 예외를 더 구체적으로 처리
- `FeignException`과 일반 예외를 구분하여 처리
- `NullPointerException` 방지를 위한 안전한 코드 작성

### 2. 테스트 용이성

- 의존성 주입을 통한 Mock 테스트 가능
- 각 서비스별 독립적인 테스트 작성
- 실제 외부 API 호출 없이 테스트 가능

### 기술적 접근
- **Mock 테스트를 통한 독립적인 테스트 환경 구축**
  - 외부 API 호출 없이 테스트 가능
  - 각 서비스별 독립적인 테스트 작성
- **의존성 주입 패턴 적용**
  - 생성자 주입을 통한 테스트 용이성 향상
  - 명시적인 의존성 관리
- **일관된 예외 처리 패턴**
  - `BusinessException`을 통한 표준화된 에러 처리
  - 구체적인 에러 코드와 메시지 제공

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #405
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-154](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- **외부 API 의존성**: Mailgun API, Google reCAPTCHA API
- **테스트 환경**: 실제 외부 API 호출 없이 Mock을 통한 테스트 가능
- **의존성 주입 변경**: 생성자 주입 방식으로 변경하여 테스트 용이성 향상
---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
