### PR TITLE
MYCE-174 refactor: 계정 찾기 중복 데이터 처리 추가

### DIFF
--- a/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
@@ -4,6 +4,8 @@ import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
 import com.cMall.feedShop.user.application.dto.response.UserResponse;
 import com.cMall.feedShop.user.domain.model.User;
 
+import java.util.List;
+
 public interface UserService {
     UserResponse signUp(UserSignUpRequest request);
 
@@ -25,6 +27,6 @@ public interface UserService {
 
     void withdrawCurrentUserWithPassword(String email, String rawPassword);
 
-    UserResponse findByUsernameAndPhoneNumber(String username, String phoneNumber);
+    List<UserResponse> findByUsernameAndPhoneNumber(String username, String phoneNumber);
 }
 

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.cMall.feedShop.user.domain.repository;
 import com.cMall.feedShop.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -17,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByVerificationToken(String verificationToken);
 
-    Optional<User> findByUserProfile_NameAndUserProfile_Phone(String name, String phone);
+    List<User> findByUserProfile_NameAndUserProfile_Phone(String name, String phone);
 }

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
@@ -18,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -54,19 +56,13 @@ public class UserAuthController {
 
     @GetMapping("/find-account")
     @ApiResponseFormat(message = "계정 조회 처리 완료.")
-    public ResponseEntity<ApiResponse<UserResponse>> findAccountByNameAndPhone(
+    public ResponseEntity<ApiResponse<List<UserResponse>>> findAccountByNameAndPhone(
             @RequestParam("username") String username,
             @RequestParam("phoneNumber") String phoneNumber
     ) {
-        UserResponse account = userService.findByUsernameAndPhoneNumber(username, phoneNumber);
+        List<UserResponse> accounts = userService.findByUsernameAndPhoneNumber(username, phoneNumber);
 
-        if (account != null) {
-            // 성공 시 200 OK를 반환합니다.
-            return new ResponseEntity<>(ApiResponse.success("계정을 성공적으로 찾았습니다.", account), HttpStatus.OK);
-        } else {
-            // 실패 시 404 NOT_FOUND를 반환합니다.
-            return new ResponseEntity<>(ApiResponse.error("해당하는 계정을 찾을 수 없습니다."), HttpStatus.NOT_FOUND);
-        }
+        return new ResponseEntity<>(ApiResponse.success("계정을 성공적으로 찾았습니다.", accounts), HttpStatus.OK);
     }
 
     @PostMapping("/forgot-password")


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
계정 찾기 API를 이름과 전화번호가 중복될 수 있는 경우를 처리하도록 수정

**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
기존에는 이름과 휴대전화번호를 사용하여 계정을 찾을 때, 중복된 데이터가 있으면 에러가 발생했습니다. 이를 해결하기 위해 백엔드 API가 여러 계정을 반환할 수 있도록 로직을 변경했습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
이름과 휴대전화번호는 현실적으로 동명이인이나 가족 내 공유 등으로 인해 중복될 수 있는 정보입니다. 기존 로직은 이러한 상황을 처리하지 못해 사용자 경험을 저해했습니다. 이 수정은 보다 유연하고 안정적인 계정 찾기 기능을 제공하기 위해 필요했습니다.

---

## 🔧 How (구현 방법)
### 주요 변경사항
(UserService, UserAuthController):

findByUsernameAndPhoneNumber 메서드가 Optional<User> 대신 List<User>를 반환하도록 변경했습니다.

이름과 전화번호가 일치하는 계정이 여러 개일 경우, 모두 조회하여 리스트로 반환합니다.

탈퇴(DELETED) 상태의 계정은 결과에서 제외하고, 미인증(PENDING) 계정은 예외를 발생시킵니다.

UserAuthController의 반환 타입을 ResponseEntity<ApiResponse<UserResponse>>에서 ResponseEntity<ApiResponse<List<UserResponse>>>로 변경하여 여러 계정을 처리할 수 있도록 했습니다.

### 기술적 접근
- UserService에서 JPA Repository의 findByUserProfile_NameAndUserProfile_Phone 메서드가 List<User>를 반환하도록 수정했습니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

개발 환경에서 동일한 이름과 전화번호를 가진 여러 계정을 생성합니다.

계정 찾기 페이지에서 해당 정보를 입력하여, 여러 계정의 이메일 목록이 올바르게 표시되는지 확인합니다.

일치하는 계정이 하나만 있을 경우, 단일 계정 정보가 올바르게 표시되는지 확인합니다.

일치하는 계정이 없는 경우, "계정을 찾을 수 없습니다"라는 오류 메시지가 표시되는지 확인합니다.

탈퇴된 계정은 검색 결과에 포함되지 않는지, 미인증 계정은 예외 처리되는지 확인합니다.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #336
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-174](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

이 변경사항으로 인해 프론트엔드와 백엔드 모두 반환 타입 및 처리 로직이 변경되었으니, 코드 리뷰 시 양쪽을 모두 확인해주시기 바랍니다.

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
