### PR TITLE
feat: 로컬 캐시 테스트 환경 추가

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,47 @@
+# 로컬 개발환경 (Docker Compose 사용)
+SPRING_APPLICATION_NAME=feedShop-local
+
+# 로컬 Docker MySQL 설정
+DB_HOST=localhost
+DB_PORT=3308
+DB_NAME=feedshop_dev
+DB_USERNAME=devuser
+DB_PASSWORD=dev123!!
+
+# SSL 비활성화 (로컬 개발용)
+SSL_ENABLED=false
+
+# JWT 설정 (개발용)
+JWT_SECRET=local-dev-jwt-secret-key-for-testing-only
+
+# Mailgun 설정 (테스트용 - 실제 메일 발송 안됨)
+MAILGUN_API_KEY=test-mailgun-key
+MAILGUN_DOMAIN=test.local
+MAILGUN_EMAIL=test@local.dev
+
+# GCS 비활성화 (로컬 개발용)
+GCS_ID=test-project
+GCS_DEV_BUCKET=test-bucket
+
+# reCAPTCHA 비활성화 (개발용)
+RECAPTCHA_SECRET_KEY=test-recaptcha-key
+
+# OAuth 비활성화 (개발용)
+GOOGLE_CLIENT_ID=test-google-client-id
+GOOGLE_CLIENT_SECRET=test-google-client-secret
+KAKAO_CLIENT_ID=test-kakao-client-id
+KAKAO_CLIENT_SECRET=test-kakao-client-secret
+
+# OpenAI 비활성화 (개발용)
+OPENAI_API_KEY=test-openai-key
+
+# 캐시 설정 (로컬 테스트용)
+REDIS_ENABLED=true
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# Caffeine 캐시 설정
+CAFFEINE_MAX_SIZE=200
+CAFFEINE_EXPIRE_MINUTES=10
+CAFFEINE_RECORD_STATS=true

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+
+services:
+  mysql-dev:
+    image: mysql:8.0
+    container_name: mysql-dev
+    ports:
+      - "3308:3306"  # 로컬 MySQL과 충돌 방지
+    environment:
+      MYSQL_ROOT_PASSWORD: dev123!!
+      MYSQL_DATABASE: feedshop_dev
+      MYSQL_USER: devuser
+      MYSQL_PASSWORD: dev123!!
+    volumes:
+      - mysql_dev_data:/var/lib/mysql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  redis-dev:
+    image: redis:7-alpine
+    container_name: redis-dev
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_dev_data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    container_name: redis-commander
+    hostname: redis-commander
+    ports:
+      - "8081:8081"
+    environment:
+      - REDIS_HOSTS=local:redis-dev:6379
+    depends_on:
+      - redis-dev
+    restart: unless-stopped
+
+volumes:
+  mysql_dev_data:
+  redis_dev_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,26 @@ services:
     networks:
       - springboot-network
     restart: always
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis-cache
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD:-}
+    volumes:
+      - redis_data:/data
+    networks:
+      - springboot-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 volumes:
   mysql_data:
+  redis_data:
 
 networks:
   springboot-network:

--- a/docs/CACHE_SETUP.md
+++ b/docs/CACHE_SETUP.md
@@ -1,0 +1,165 @@
+# 캐시 시스템 설정 가이드
+
+## 🚀 로컬에서 완전 독립 캐시 테스트하기
+
+### 🎯 Quick Start (클라우드 DB 없이 로컬 완전 독립)
+
+```bash
+# Windows
+scripts\test-cache-local.bat
+
+# Linux/Mac
+chmod +x scripts/test-cache-local.sh
+./scripts/test-cache-local.sh
+
+# 애플리케이션 실행
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+### 1. 로컬 완전 독립 환경 (추천)
+
+클라우드 DB가 죽어있어도 테스트 가능한 완전 독립 환경:
+
+```bash
+# 1단계: 로컬 MySQL + Redis 실행
+docker-compose -f docker-compose.local.yml up -d
+
+# 2단계: 로컬 프로파일로 애플리케이션 실행
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+**포함 서비스:**
+- MySQL (포트 3308)
+- Redis (포트 6379)  
+- Redis Commander (포트 8081)
+
+### 2. 기존 개발환경에서 Redis 추가 테스트
+
+기존 클라우드 DB + Redis 조합:
+
+```bash
+# 1단계: Redis만 실행
+docker run -d --name redis-test -p 6379:6379 redis:7-alpine
+
+# 2단계: Redis 활성화하여 실행
+REDIS_ENABLED=true ./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+### 4. 캐시 동작 확인
+
+#### 4.1 캐시 통계 확인
+```bash
+curl http://localhost:8443/api/admin/cache/stats
+```
+
+#### 4.2 베스트 상품 조회 (캐시 생성)
+```bash
+curl http://localhost:8443/api/products/best?limit=10
+```
+
+#### 4.3 캐시 무효화 테스트
+```bash
+curl -X DELETE http://localhost:8443/api/admin/cache/products
+```
+
+### 5. Redis Commander로 캐시 데이터 확인
+
+Redis Commander가 자동으로 실행됩니다:
+- URL: http://localhost:8081
+- Redis 서버: local (redis-dev:6379)
+
+## 🔧 환경별 캐시 설정
+
+### 개발환경 (application-dev.properties)
+```properties
+# Caffeine Cache (L1)
+spring.cache.caffeine.maximum-size=500
+spring.cache.caffeine.expire-after-write=15
+spring.cache.caffeine.record-stats=true
+
+# Redis Cache (L2) - 선택적 활성화
+spring.cache.redis.enabled=${REDIS_ENABLED:false}
+spring.cache.redis.time-to-live=30
+```
+
+### 테스트환경 (application-test.properties)
+```properties
+# Caffeine Cache (L1) - 테스트용 최소값
+spring.cache.caffeine.maximum-size=100
+spring.cache.caffeine.expire-after-write=5
+spring.cache.caffeine.record-stats=true
+
+# Redis Cache (L2) - 비활성화
+spring.cache.redis.enabled=false
+```
+
+### 운영환경 (application.properties)
+```properties
+# Caffeine Cache (L1)
+spring.cache.caffeine.maximum-size=${CAFFEINE_MAX_SIZE:1000}
+spring.cache.caffeine.expire-after-write=${CAFFEINE_EXPIRE_MINUTES:30}
+spring.cache.caffeine.record-stats=${CAFFEINE_RECORD_STATS:true}
+
+# Redis Cache (L2)
+spring.cache.redis.enabled=${REDIS_ENABLED:false}
+spring.cache.redis.time-to-live=${REDIS_TTL_MINUTES:60}
+```
+
+## 📊 캐시 성능 모니터링
+
+### 캐시 히트율 확인
+```bash
+# 캐시 통계 로그 출력
+curl http://localhost:8443/api/admin/cache/stats
+```
+
+### 예상 로그 출력
+```
+=== 캐시 통계 정보 ===
+캐시 이름: categories
+  - 요청 수: 150
+  - 히트 수: 145
+  - 미스 수: 5
+  - 히트율: 96.67%
+  - 평균 로드 시간: 12.34ms
+  - 캐시 크기: 8
+
+캐시 이름: bestProducts
+  - 요청 수: 89
+  - 히트 수: 76
+  - 미스 수: 13
+  - 히트율: 85.39%
+  - 평균 로드 시간: 45.67ms
+  - 캐시 크기: 12
+```
+
+## 🛠 트러블슈팅
+
+### Redis 연결 실패 시
+1. Docker 컨테이너 상태 확인: `docker ps`
+2. Redis 로그 확인: `docker logs redis-dev`
+3. 포트 충돌 확인: `netstat -an | grep 6379`
+
+### 캐시가 동작하지 않을 때
+1. `@EnableCaching` 어노테이션 확인
+2. 캐시 매니저 빈 등록 확인
+3. 메서드에 `@Cacheable` 어노테이션 확인
+4. 프록시 호출 여부 확인 (같은 클래스 내부 호출은 캐시 안됨)
+
+## 🔄 캐시 무효화 전략
+
+### 자동 무효화 (AOP 기반)
+- 상품 생성/수정/삭제 시 자동으로 관련 캐시 무효화
+- `ProductCacheService`에서 처리
+
+### 수동 무효화 (관리자용)
+```bash
+# 모든 상품 캐시 무효화
+curl -X DELETE http://localhost:8443/api/admin/cache/products
+
+# 카테고리 캐시 무효화
+curl -X DELETE http://localhost:8443/api/admin/cache/categories
+
+# 특정 카테고리 베스트 상품 캐시 무효화
+curl -X DELETE http://localhost:8443/api/admin/cache/products/best/category/1
+```

--- a/scripts/test-cache-local.bat
+++ b/scripts/test-cache-local.bat
@@ -1,0 +1,51 @@
+@echo off
+chcp 65001 > nul
+echo 🚀 로컬 캐시 테스트 환경 설정
+
+REM 1. Docker 서비스 시작
+echo 📦 Docker 서비스 시작 중...
+docker-compose -f ../docker-compose.local.yml up -d
+
+REM 2. 서비스 헬스체크 대기
+echo ⏳ 서비스 준비 대기 중...
+timeout /t 10 /nobreak > nul
+
+REM 3. MySQL 연결 테스트
+echo 🗄️ MySQL 연결 테스트...
+docker exec mysql-dev mysqladmin ping -h localhost -u devuser -pdev123!!
+if %errorlevel% neq 0 (
+    echo ❌ MySQL 연결 실패
+    exit /b 1
+)
+
+REM 4. Redis 연결 테스트
+echo 🔴 Redis 연결 테스트...
+docker exec redis-dev redis-cli ping
+if %errorlevel% neq 0 (
+    echo ❌ Redis 연결 실패
+    exit /b 1
+)
+
+echo ✅ 모든 서비스가 준비되었습니다!
+echo.
+echo 🎯 다음 명령어로 애플리케이션을 실행하세요:
+echo    gradlew bootRun --args="--spring.profiles.active=local"
+echo.
+echo 📊 테스트 URL:
+echo    - 베스트 상품: http://localhost:8080/api/products/best
+echo    - 카테고리: http://localhost:8080/api/products/categories
+echo    - 캐시 통계: http://localhost:8080/api/admin/cache/stats
+echo    - Redis Commander: http://localhost:8081
+echo    - 업로드된 파일: http://localhost:8080/local-uploads/
+echo.
+echo 🧪 캐시 테스트 명령어 (인증 불필요):
+echo    curl http://localhost:8080/api/products/best?limit=5
+echo    curl http://localhost:8080/api/products/categories
+echo    curl http://localhost:8080/api/admin/cache/stats
+echo.
+echo 💡 로컬 환경(local 프로파일)에서는 모든 API가 인증 없이 접근 가능합니다.
+echo.
+echo 🛑 테스트 완료 후 정리:
+echo    docker-compose -f ../docker-compose.local.yml down
+
+pause

--- a/scripts/test-cache-local.sh
+++ b/scripts/test-cache-local.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+echo "🚀 로컬 캐시 테스트 환경 설정"
+
+# 1. Docker 서비스 시작
+echo "📦 Docker 서비스 시작 중..."
+docker-compose -f ../docker-compose.local.yml up -d
+
+# 2. 서비스 헬스체크 대기
+echo "⏳ 서비스 준비 대기 중..."
+sleep 10
+
+# 3. MySQL 연결 테스트
+echo "🗄️ MySQL 연결 테스트..."
+docker exec mysql-dev mysqladmin ping -h localhost -u devuser -pdev123!! || {
+    echo "❌ MySQL 연결 실패"
+    exit 1
+}
+
+# 4. Redis 연결 테스트
+echo "🔴 Redis 연결 테스트..."
+docker exec redis-dev redis-cli ping || {
+    echo "❌ Redis 연결 실패"
+    exit 1
+}
+
+echo "✅ 모든 서비스가 준비되었습니다!"
+echo ""
+echo "🎯 다음 명령어로 애플리케이션을 실행하세요:"
+echo "   ./gradlew bootRun --args='--spring.profiles.active=local'"
+echo ""
+echo "📊 테스트 URL:"
+echo "   - 베스트 상품: http://localhost:8080/api/products/best"
+echo "   - 카테고리: http://localhost:8080/api/products/categories"
+echo "   - 캐시 통계: http://localhost:8080/api/admin/cache/stats"
+echo "   - Redis Commander: http://localhost:8081"
+echo "   - 업로드된 파일: http://localhost:8080/local-uploads/"
+echo ""
+echo "🧪 캐시 테스트 명령어 (인증 불필요):"
+echo "   curl http://localhost:8080/api/products/best?limit=5"
+echo "   curl http://localhost:8080/api/products/categories"
+echo "   curl http://localhost:8080/api/admin/cache/stats"
+echo ""
+echo "💡 로컬 환경(local 프로파일)에서는 모든 API가 인증 없이 접근 가능합니다."
+echo "   개발환경(dev)과 운영환경(prod)은 별도 인증 설정을 사용합니다."
+echo ""
+echo "🛑 테스트 완료 후 정리:"
+echo "   docker-compose -f ../docker-compose.local.yml down"

--- a/src/main/java/com/cMall/feedShop/product/application/service/ProductCacheService.java
+++ b/src/main/java/com/cMall/feedShop/product/application/service/ProductCacheService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 /**
  * 상품 관련 캐시 관리 통합 서비스
  * - 수동 캐시 무효화
- * - AOP 기반 자동 캐시 무효화  
+ * - AOP 기반 자동 캐시 무효화
  * - 캐시 통계 및 모니터링
  */
 @Slf4j
@@ -19,12 +19,12 @@ public class ProductCacheService {
     private final CacheManager cacheManager;
 
     // ========== AOP 기반 자동 캐시 무효화 ==========
-    
+
     /**
      * 상품 생성 시 캐시 무효화
      * - 새로운 상품이 추가되면 베스트 상품 목록이 변경될 수 있음
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictOnProductCreate() {
         log.info("상품 생성으로 인한 캐시 무효화 실행");
     }
@@ -33,7 +33,7 @@ public class ProductCacheService {
      * 상품 수정 시 캐시 무효화
      * - 상품 정보 변경으로 인해 베스트 상품 순위가 변경될 수 있음
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictOnProductUpdate() {
         log.info("상품 수정으로 인한 캐시 무효화 실행");
     }
@@ -42,7 +42,7 @@ public class ProductCacheService {
      * 상품 삭제 시 캐시 무효화
      * - 상품이 삭제되면 베스트 상품 목록에서 제외되어야 함
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictOnProductDelete() {
         log.info("상품 삭제로 인한 캐시 무효화 실행");
     }
@@ -51,7 +51,7 @@ public class ProductCacheService {
      * 상품 재고 변경 시 캐시 무효화
      * - 재고 상태 변경으로 인해 재고 필터링된 베스트 상품 목록이 변경될 수 있음
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictOnStockChange() {
         log.info("상품 재고 변경으로 인한 캐시 무효화 실행");
     }
@@ -60,7 +60,7 @@ public class ProductCacheService {
      * 상품 인기도 변경 시 캐시 무효화 (위시리스트, 주문 등)
      * - 인기도 변경으로 인해 베스트 상품 순위가 변경될 수 있음
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictOnPopularityChange() {
         log.info("상품 인기도 변경으로 인한 캐시 무효화 실행");
     }
@@ -69,7 +69,7 @@ public class ProductCacheService {
      * 카테고리 변경 시 캐시 무효화
      * - 카테고리 정보 변경으로 인해 카테고리 목록과 카테고리별 베스트 상품이 변경될 수 있음
      */
-    @CacheEvict(value = {"categories", "bestProducts"}, allEntries = true)
+    @CacheEvict(value = { "categories", "bestProducts" }, allEntries = true)
     public void evictOnCategoryChange() {
         log.info("카테고리 변경으로 인한 캐시 무효화 실행");
     }
@@ -80,7 +80,7 @@ public class ProductCacheService {
      * 모든 상품 관련 캐시 무효화
      * - 상품 정보가 변경될 때 호출
      */
-    @CacheEvict(value = {"bestProducts", "popularProducts"}, allEntries = true)
+    @CacheEvict(value = { "bestProducts", "popularProducts" }, allEntries = true)
     public void evictAllProductCaches() {
         log.info("모든 상품 캐시를 무효화합니다.");
     }
@@ -120,15 +120,28 @@ public class ProductCacheService {
      * 캐시 통계 정보 조회 (모니터링용)
      */
     public void logCacheStats() {
-        var caffeineCacheManager = cacheManager;
         log.info("=== 캐시 통계 정보 ===");
-        
-        caffeineCacheManager.getCacheNames().forEach(cacheName -> {
-            var cache = caffeineCacheManager.getCache(cacheName);
+
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            var cache = cacheManager.getCache(cacheName);
             if (cache != null) {
                 log.info("캐시 이름: {}", cacheName);
-                // Caffeine 캐시의 경우 통계 정보 출력 가능
-                // cache.getNativeCache() 를 통해 접근 가능
+
+                // Caffeine 캐시의 경우 상세 통계 정보 출력
+                var nativeCache = cache.getNativeCache();
+                if (nativeCache instanceof com.github.benmanes.caffeine.cache.Cache) {
+                    var caffeineCache = (com.github.benmanes.caffeine.cache.Cache<?, ?>) nativeCache;
+                    var stats = caffeineCache.stats();
+
+                    log.info("  - 요청 수: {}", stats.requestCount());
+                    log.info("  - 히트 수: {}", stats.hitCount());
+                    log.info("  - 미스 수: {}", stats.missCount());
+                    log.info("  - 히트율: {:.2f}%", stats.hitRate() * 100);
+                    log.info("  - 평균 로드 시간: {:.2f}ms", stats.averageLoadPenalty() / 1_000_000.0);
+                    log.info("  - 캐시 크기: {}", caffeineCache.estimatedSize());
+                } else {
+                    log.info("  - 캐시 타입: {}", nativeCache.getClass().getSimpleName());
+                }
             }
         });
     }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,112 @@
+spring.application.name=${SPRING_APPLICATION_NAME:feedshop-local}
+
+# 로컬 Docker MySQL 설정
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3308}/${DB_NAME:feedshop_dev}?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=${DB_USERNAME:devuser}
+spring.datasource.password=${DB_PASSWORD:dev123!!}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA 설정 (로컬 개발용)
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.devtools.restart.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# 서버 설정 (SSL 비활성화)
+server.port=${SERVER_PORT:8080}
+server.ssl.enabled=false
+
+# 시간 설정
+spring.jackson.time-zone=Asia/Seoul
+spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
+
+# 파일 업로드 설정
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.file-size-threshold=2KB
+
+# form data
+spring.mvc.hiddenmethod.filter.enabled=true
+
+# 메일 설정 (테스트용)
+mailgun.api.key=${MAILGUN_API_KEY:test-key}
+mailgun.domain=${MAILGUN_DOMAIN:test.local}
+mailgun.from.email=${MAILGUN_EMAIL:test@local.dev}
+
+# 파일 스토리지 설정 (로컬 파일 시스템 사용)
+spring.cloud.gcp.project-id=${GCS_ID:test-project}
+spring.cloud.gcp.storage.bucket=${GCS_DEV_BUCKET:test-bucket}
+spring.cloud.gcp.storage.auto-create-buckets=false
+file.upload.base-path=./local-uploads
+file.upload.cache-period=3600
+app.cdn.base-url=http://localhost:8080
+
+# 로컬 파일 업로드 디렉토리 생성
+spring.servlet.multipart.location=./local-uploads/temp
+
+# 로깅 설정
+logging.level.org.springframework=INFO
+logging.level.root=INFO
+logging.level.com.cMall.feedShop=DEBUG
+logging.level.com.cMall.feedShop.common.aop=INFO
+
+# 로깅 패턴
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId:-}] %logger{36} - %msg%n
+
+# 액추에이터 설정
+management.endpoints.web.exposure.include=health,info,cache
+management.endpoint.health.show-details=always
+
+# URL 설정 (로컬용)
+app.verification-url=http://localhost:8080/api/auth/verify-email?token=
+app.password-reset-url=http://localhost:3000/reset-password
+
+# reCAPTCHA 설정 (비활성화)
+recaptcha.enabled=false
+recaptcha.secret-key=${RECAPTCHA_SECRET_KEY:test-key}
+recaptcha.score-threshold=0.5
+
+# JWT 설정
+jwt.secret=${JWT_SECRET:local-dev-jwt-secret-key-for-testing-only}
+jwt.access-token-expiration-ms=3600000
+jwt.refresh-token-expiration-ms=1209600000
+
+# OAuth2 설정 (비활성화)
+app.oauth2.authorized-redirect-uri=http://localhost:3000/auth/callback
+
+# Google OAuth (테스트용)
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:test-google-client-id}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:test-google-client-secret}
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+
+# Kakao OAuth (테스트용)
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:test-kakao-client-id}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET:test-kakao-client-secret}
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.scope=account_email,profile_nickname,profile_image
+
+# Spring AI (비활성화)
+ai.enabled=false
+spring.ai.openai.api-key=${OPENAI_API_KEY:test-openai-key}
+
+# Cache Configuration (로컬 테스트환경)
+# Caffeine Cache (L1) 설정 - 로컬 테스트용
+spring.cache.caffeine.maximum-size=${CAFFEINE_MAX_SIZE:200}
+spring.cache.caffeine.expire-after-write=${CAFFEINE_EXPIRE_MINUTES:10}
+spring.cache.caffeine.record-stats=${CAFFEINE_RECORD_STATS:true}
+
+# Redis Cache (L2) 설정 - 로컬 Docker Redis
+spring.cache.redis.enabled=${REDIS_ENABLED:true}
+spring.cache.redis.time-to-live=15
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:}
+spring.data.redis.timeout=2000ms
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+spring.data.redis.lettuce.pool.min-idle=0

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -73,6 +73,16 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 # OAuth2
 app.oauth2.authorized-redirect-uri=http://localhost:3000/auth/callback
 
+# Cache Configuration (테스트환경)
+# Caffeine Cache (L1) 설정 - 테스트용 최소값
+spring.cache.caffeine.maximum-size=100
+spring.cache.caffeine.expire-after-write=5
+spring.cache.caffeine.record-stats=true
+
+# Redis Cache (L2) 설정 - 테스트환경에서는 비활성화
+spring.cache.redis.enabled=false
+spring.cache.redis.time-to-live=10
+
 # Spring AI
 ai.enabled=false
 spring.ai.openai.api-key=${OPENAI_API_KEY:test-openai-api-key}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
캐시 시스템을 구현하고, 로컬 환경에서 테스트할 수 있도록 구성했습니다.


**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
 - 로컬 테스트를 위한 test-cache-local.bat, test-cache-local.sh 스크립트와 docker-compose.dev.yml
  파일을 추가하여 개발 환경의 편의성을 높였습니다.


### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
운영 및 클라우드에서 진행하는 개발이 아닌 로컬 환경에서 캐시 테스트 

---

## 🔧 How (구현 방법)
### 주요 변경사항
  - docker-compose.local.yml 추가: 로컬 개발용 Redis 컨테이너 설정
  - 테스트 스크립트 추가: 로컬에서 캐시 관련 테스트를 쉽게 실행할 수 있도록 스크립트 추가


### 기술적 접근
  - Spring Cache Abstraction과 Redis를 연동하여 캐시 기능을 구현했습니다.
  - @Cacheable, @CacheEvict 어노테이션을 사용하여 선언적으로 캐시를 관리합니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
로컬 환경에서 test-cache-local.sh 또는 test-cache-local.bat 스크립트를 실행하여 Docker로 Redis를
 띄운 후, 관련 API를 요청하여 캐시가 정상적으로 동작하는지 확인했습니다.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
  로컬에서 테스트하려면 Docker와 Docker Compose가 설치되어 있어야 합니다. scripts 폴더의
  test-cache-local 스크립트를 실행하면 개발용 Redis 컨테이너가 실행됩니다.

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
