### PR TITLE
feat: 로컬 개발환경 완전 독립 구성 및 파일 업로드 시스템 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ src/main/resources/application-dev.properties
 application.yml
 logs/
 
+# Local file uploads
+local-uploads/
+uploads/
+temp/
+
 # Gradle
 .gradle/
 build/

--- a/src/main/java/com/cMall/feedShop/common/storage/MockStorageService.java
+++ b/src/main/java/com/cMall/feedShop/common/storage/MockStorageService.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
-@Profile("dev")
+@Profile({"dev", "local", "test"})
 public class MockStorageService implements StorageService {
 
     @Value("${app.cdn.base-url}")

--- a/src/main/java/com/cMall/feedShop/config/LocalFileConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/LocalFileConfig.java
@@ -1,0 +1,57 @@
+package com.cMall.feedShop.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 로컬 개발환경용 파일 업로드 디렉토리 설정
+ */
+@Slf4j
+@Configuration
+@Profile({"local", "test"})
+public class LocalFileConfig {
+
+    @Value("${file.upload.base-path:./local-uploads}")
+    private String uploadBasePath;
+
+    @PostConstruct
+    public void createUploadDirectories() {
+        try {
+            // 기본 업로드 디렉토리 생성
+            createDirectoryIfNotExists(uploadBasePath);
+            
+            // 각 업로드 타입별 디렉토리 생성
+            createDirectoryIfNotExists(uploadBasePath + "/images");
+            createDirectoryIfNotExists(uploadBasePath + "/images/products");
+            createDirectoryIfNotExists(uploadBasePath + "/images/feeds");
+            createDirectoryIfNotExists(uploadBasePath + "/images/reviews");
+            createDirectoryIfNotExists(uploadBasePath + "/images/profiles");
+            createDirectoryIfNotExists(uploadBasePath + "/temp");
+            
+            log.info("✅ 로컬 파일 업로드 디렉토리 생성 완료: {}", uploadBasePath);
+            
+        } catch (Exception e) {
+            log.error("❌ 로컬 파일 업로드 디렉토리 생성 실패", e);
+        }
+    }
+
+    private void createDirectoryIfNotExists(String directoryPath) {
+        try {
+            Path path = Paths.get(directoryPath);
+            if (!Files.exists(path)) {
+                Files.createDirectories(path);
+                log.debug("디렉토리 생성: {}", directoryPath);
+            }
+        } catch (Exception e) {
+            log.error("디렉토리 생성 실패: {}", directoryPath, e);
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/LocalSecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/LocalSecurityConfig.java
@@ -1,0 +1,71 @@
+package com.cMall.feedShop.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 로컬 개발환경 전용 Security 설정
+ * - 모든 API 인증 없이 접근 가능
+ * - 캐시 테스트 및 기능 개발에 최적화
+ */
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@Profile("local")
+public class LocalSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain localSecurityFilterChain(HttpSecurity http) throws Exception {
+        log.info("🔓 로컬 개발환경: 모든 API 인증 없이 접근 가능");
+        
+        http
+                // CSRF 보호 비활성화 (로컬 테스트 편의성)
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                
+                // 모든 요청에 대해 인증 없이 접근 허용
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                
+                // 폼 로그인 및 HTTP Basic 인증 비활성화
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable());
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        
+        // 로컬 개발환경에서 허용할 Origin 목록
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",    // React 개발 서버
+                "http://localhost:8080",    // Spring Boot 서버
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:8080"
+        ));
+        
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
+        config.setAllowCredentials(true); // 자격 증명 허용
+        config.setMaxAge(3600L); // 1시간 캐시
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        
+        return source;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/LocalWebConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/LocalWebConfig.java
@@ -1,0 +1,37 @@
+package com.cMall.feedShop.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 로컬 개발환경용 정적 파일 서빙 설정
+ */
+@Slf4j
+@Configuration
+@Profile("local")
+public class LocalWebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.base-path:./local-uploads}")
+    private String uploadBasePath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 로컬 업로드 파일 서빙
+        String resourceLocation = "file:" + uploadBasePath + "/";
+        
+        registry.addResourceHandler("/local-uploads/**")
+                .addResourceLocations(resourceLocation)
+                .setCachePeriod(3600);
+        
+        // Mock 이미지 서빙 (MockStorageService에서 생성된 URL용)
+        registry.addResourceHandler("/mock/**")
+                .addResourceLocations(resourceLocation)
+                .setCachePeriod(3600);
+        
+        log.info("✅ 로컬 정적 파일 서빙 설정 완료: {} -> {}", "/local-uploads/**", resourceLocation);
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
로컬 개발환경 완전 독립 구성 및 파일 업로드 시스템 개선

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why
### 무엇을 했나요?
- **로컬 환경 전용 Security 설정**: 인증 없이 모든 API 접근 가능한 `LocalSecurityConfig` 추가
- **로컬 파일 업로드 시스템**: 자동 디렉토리 생성 및 정적 파일 서빙 설정
- **환경별 파일 스토리지 전략 명확화**: 로컬/개발/운영 환경별 파일 처리 방식 분리
- **MockStorageService 개선**: 로컬 파일 시스템 기반 파일 업로드 Mock 처리
- **개발 편의성 향상**: 클라우드 인프라 없이도 완전한 기능 테스트 가능

### 왜 필요했나요?
- **개발 환경 독립성**: 클라우드 DB나 GCS 장애 시에도 로컬에서 완전한 개발 가능
- **파일 업로드 테스트**: 로컬에서 이미지 업로드/다운로드 기능 테스트 필요
- **인증 복잡성 제거**: 캐시 및 API 테스트 시 JWT 토큰 없이 빠른 테스트 가능
- **비용 절약**: 개발 중 불필요한 클라우드 리소스 사용 방지

---

## 🔧 How (구현 방법)
### 주요 변경사항
- **새로운 설정 클래스**:
  - `LocalSecurityConfig`: 로컬 환경 전용 보안 설정 (모든 API 인증 없이 접근)
  - `LocalFileConfig`: 로컬 파일 업로드 디렉토리 자동 생성
  - `LocalWebConfig`: 로컬 정적 파일 서빙 설정
- **MockStorageService 개선**: 프로파일 확장 및 로컬 파일 시스템 연동
- **Git 설정**: 로컬 업로드 디렉토리 `.gitignore` 추가

### 환경별 파일 스토리지 전략
- **로컬 (`local`)**: MockStorageService + 로컬 파일 시스템
- **개발 (`dev`)**: MockStorageService + 클라우드 DB
- **테스트 (`test`)**: MockStorageService + H2 DB
- **운영 (`prod`)**: GcpStorageService + 실제 GCS

---

## 🧪 Testing
### 테스트 방법
- **로컬 완전 독립 환경**: Docker Compose로 MySQL + Redis 구성
- **파일 업로드 테스트**: 로컬에서 이미지 업로드 후 HTTP 접근 확인
- **API 인증 테스트**: JWT 토큰 없이 모든 API 접근 가능 확인
- **캐시 + 파일 업로드 통합 테스트**: 전체 기능 연동 테스트

### 확인 사항
- [x] 로컬 환경에서 모든 API 인증 없이 접근 가능
- [x] 파일 업로드 디렉토리 자동 생성 확인
- [x] 업로드된 파일 HTTP 접근 가능 확인
- [x] 기존 개발/운영 환경 영향 없음
- [x] MockStorageService 정상 동작 확인

---

## 📎 관련 이슈 / 문서
- 관련 이슈: 로컬 개발환경 독립성 확보
- 지라 백로그: 개발 효율성 향상

---

## 💬 Additional Notes
### 로컬 환경 사용법
```bash
# 1단계: 로컬 환경 구성
docker-compose -f docker-compose.local.yml up -d

# 2단계: 애플리케이션 실행
./gradlew bootRun --args='--spring.profiles.active=local'

# 3단계: 테스트
curl http://localhost:8080/api/products/best        # 인증 불필요
curl http://localhost:8080/api/products/categories  # 인증 불필요
curl http://localhost:8080/api/admin/cache/stats    # 인증 불필요

```

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
