### PR TITLE
fix: ci 오류 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,12 @@ jobs:
       - name: Clean and Test
         run: |
           ./gradlew clean
+<<<<<<< Updated upstream
           ./gradlew test jacocoTestReport --info
+=======
+          ./gradlew test --info --stacktrace --continue
+          ./gradlew jacocoTestReport
+>>>>>>> Stashed changes
         env:
           SPRING_PROFILES_ACTIVE: test
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,8 @@ jobs:
       - name: Clean and Test
         run: |
           ./gradlew clean
-<<<<<<< Updated upstream
-          ./gradlew test jacocoTestReport --info
-=======
           ./gradlew test --info --stacktrace --continue
           ./gradlew jacocoTestReport
->>>>>>> Stashed changes
         env:
           SPRING_PROFILES_ACTIVE: test
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CI 파이프라인의 Clean and Test 단계에서 Gradle 태스크 실행 순서와 옵션을 분리하여 빌드 안정성 및 오류 디버깅을 개선합니다.

**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [x] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
test 태스크와 jacocoTestReport 태스크를 하나의 Gradle 명령에서 분리하여 실행하도록 CI 설정(YAML)을 수정했습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
이전 CI 실행 로그에서 **Gradle 명령줄 옵션 오류(Unknown command-line option '--tests')**가 발생하는 사례가 있었습니다 (비록 YAML 파일에 직접 --tests가 없었지만, 태스크가 혼합 실행될 때 발생할 수 있는 잠재적 혼란을 제거하기 위함).

명령어 오류 방지: 각 태스크를 명확하게 분리하여 향후 발생할 수 있는 명령줄 옵션 오류를 방지하고, Gradle의 태스크 실행 의도를 명확히 합니다.

안정성 강화: test 태스크에 --continue 옵션을 추가하여, 일부 테스트가 실패하더라도 나머지 테스트들을 끝까지 실행하도록 보장했습니다. 이는 디버깅에 필요한 모든 정보를 얻고, jacocoTestReport 생성을 위한 준비를 유지하는 데 도움이 됩니다.

디버깅 편의성: test 실행에만 --stacktrace를 적용하여 테스트 실패 시의 디버깅 정보를 얻고, 보고서 생성은 분리했습니다.
---

## 🔧 How (구현 방법)
### 주요 변경사항
test와 jacocoTestReport 태스크를 두 개의 별도 run 명령어로 분리.

test 태스크 실행 시 --continue 옵션을 추가하여 테스트 도중 실패가 발생해도 전체 테스트를 완료하도록 설정.

### 기술적 접근
GitHub Actions의 run 스텝 내에서 셸 명령어 분리를 통해 Gradle의 독립적인 태스크 실행 원칙을 준수했습니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
테스트 방법
PR 생성 후 GitHub Actions CI 파이프라인이 정상적으로 완료되는 것을 확인했습니다.

로컬 환경에서 해당 명령어로 테스트 및 보고서 생성이 정상 작동함을 확인했습니다.

확인 사항
[x] 기능 정상 동작 확인 (CI 통과 확인)
[x] 기존 기능 영향 없음 (테스트 및 보고서 생성 로직 변경 없음)
[ ] 예외 케이스 테스트 완료

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
CI 로그에서 발견된 잠재적인 Gradle 명령어 오류를 미연에 방지하기 위한 안전화 작업입니다. --continue 옵션으로 인해 test 단계에서 실패가 발생하더라도 jacocoTestReport 단계가 시도될 수 있습니다. 최종적으로는 test 단계의 성공 여부가 중요하므로, 전체 빌드 결과를 반드시 확인해 주시기 바랍니다.
---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [ ] 불필요한 로그 제거
